### PR TITLE
1.0.0-Beta14

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta13] - 2024-09-06
+
 ## [1.0.0-beta12] - 2024-08-30
 
 ## [1.0.0-beta11] - 2024-08-23
@@ -36,7 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded to Undertow latest due to security fix
 - First iteration of this module
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0-beta12...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0-beta13...HEAD
+
+[1.0.0-beta13]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0-beta12...v1.0.0-beta13
 
 [1.0.0-beta12]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0-beta11...v1.0.0-beta12
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Fri Aug 30 16:57:17 UTC 2024
-boxlangVersion=1.0.0-beta13
+#Fri Sep 06 12:11:49 UTC 2024
+boxlangVersion=1.0.0-beta14
 jdkVersion=21
-version=1.0.0-beta13
+version=1.0.0-beta14
 group=ortus.boxlang

--- a/src/main/java/ortus/boxlang/web/MiniServer.java
+++ b/src/main/java/ortus/boxlang/web/MiniServer.java
@@ -122,18 +122,22 @@ public class MiniServer {
 		// Build out the server
 		Undertow BLServer = builder
 		    .addHttpListener( port, host )
-		    .setHandler( new EncodingHandler( new ContentEncodingRepository().addEncodingHandler(
-		        "gzip", new GzipEncodingProvider(), 50, Predicates.parse( "request-larger-than(1500)" ) ) )
-		        .setNext( new WelcomeFileHandler(
-		            Handlers.predicate(
-		                // If this predicate evaluates to true, we process via BoxLang, otherwise, we serve a static file
-		                Predicates.parse( "regex( '^(/.+?\\.cfml|/.+?\\.cf[cms]|.+?\\.bx[ms]{0,1})(/.*)?$' )" ),
-		                new BLHandler( absWebRoot.toString() ),
-		                new ResourceHandler( resourceManager )
-		                    .setDirectoryListingEnabled( true ) ),
-		            resourceManager,
-		            List.of( "index.bxm", "index.bxs", "index.cfm", "index.cfs", "index.htm", "index.html" )
-		        ) ) )
+		    .setHandler(
+		        new EncodingHandler(
+		            new ContentEncodingRepository().addEncodingHandler(
+		                "gzip", new GzipEncodingProvider(), 50, Predicates.parse( "request-larger-than(1500)" )
+		            )
+		        )
+		            .setNext( new WelcomeFileHandler(
+		                Handlers.predicate(
+		                    // If this predicate evaluates to true, we process via BoxLang, otherwise, we serve a static file
+		                    Predicates.parse( "regex( '^(/.+?\\.cfml|/.+?\\.cf[cms]|.+?\\.bx[ms]{0,1})(/.*)?$' )" ),
+		                    new BLHandler( absWebRoot.toString() ),
+		                    new ResourceHandler( resourceManager )
+		                        .setDirectoryListingEnabled( true ) ),
+		                resourceManager,
+		                List.of( "index.bxm", "index.bxs", "index.cfm", "index.cfs", "index.htm", "index.html" )
+		            ) ) )
 		    .build();
 
 		// Add a shutdown hook to stop the server

--- a/src/main/java/ortus/boxlang/web/exchange/BoxHTTPUndertowExchange.java
+++ b/src/main/java/ortus/boxlang/web/exchange/BoxHTTPUndertowExchange.java
@@ -17,7 +17,6 @@
  */
 package ortus.boxlang.web.exchange;
 
-import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -27,7 +26,6 @@ import java.io.PrintWriter;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
-import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.security.Principal;
@@ -59,6 +57,7 @@ import io.undertow.util.LocaleUtils;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.web.context.WebRequestBoxContext;
+import ortus.boxlang.web.util.BlockingBufferedOutputStream;
 
 /**
  * I implement a BoxLang HTTP exchange for Undertow
@@ -521,7 +520,7 @@ public class BoxHTTPUndertowExchange implements IBoxHTTPExchange {
 	@Override
 	public PrintWriter getResponseWriter() {
 		if ( writer == null ) {
-			OutputStream outputStream = new BufferedOutputStream( Channels.newOutputStream( getResponseChannel() ), 8192 * 8192 );
+			OutputStream outputStream = new BlockingBufferedOutputStream( getResponseChannel() );
 			writer = new PrintWriter( outputStream, false );
 		}
 		return writer;

--- a/src/main/java/ortus/boxlang/web/exchange/BoxHTTPUndertowExchange.java
+++ b/src/main/java/ortus/boxlang/web/exchange/BoxHTTPUndertowExchange.java
@@ -97,7 +97,7 @@ public class BoxHTTPUndertowExchange implements IBoxHTTPExchange {
 
 	/**
 	 * Create a new BoxLang HTTP exchange for Undertow
-	 * 
+	 *
 	 * @param exchange The Undertow exchange for this request
 	 */
 	public BoxHTTPUndertowExchange( HttpServerExchange exchange ) {
@@ -106,7 +106,7 @@ public class BoxHTTPUndertowExchange implements IBoxHTTPExchange {
 
 	/**
 	 * Get the response channel for this exchange
-	 * 
+	 *
 	 * @return The response channel
 	 */
 	public synchronized StreamSinkChannel getResponseChannel() {
@@ -118,7 +118,7 @@ public class BoxHTTPUndertowExchange implements IBoxHTTPExchange {
 
 	/**
 	 * Get the Undertow exchange for this request
-	 * 
+	 *
 	 * @return The Undertow exchange
 	 */
 	public HttpServerExchange getExchange() {
@@ -521,7 +521,7 @@ public class BoxHTTPUndertowExchange implements IBoxHTTPExchange {
 	@Override
 	public PrintWriter getResponseWriter() {
 		if ( writer == null ) {
-			OutputStream outputStream = new BufferedOutputStream( Channels.newOutputStream( getResponseChannel() ) );
+			OutputStream outputStream = new BufferedOutputStream( Channels.newOutputStream( getResponseChannel() ), 8192 * 8192 );
 			writer = new PrintWriter( outputStream, false );
 		}
 		return writer;

--- a/src/main/java/ortus/boxlang/web/util/BlockingBufferedOutputStream.java
+++ b/src/main/java/ortus/boxlang/web/util/BlockingBufferedOutputStream.java
@@ -1,0 +1,55 @@
+package ortus.boxlang.web.util;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+import org.xnio.channels.StreamSinkChannel;
+
+public class BlockingBufferedOutputStream extends OutputStream {
+
+	private final StreamSinkChannel	channel;
+	private final ByteBuffer		buffer;
+
+	public BlockingBufferedOutputStream( StreamSinkChannel channel ) {
+		this.channel	= channel;
+		this.buffer		= ByteBuffer.allocate( 1024 );
+	}
+
+	@Override
+	public void write( int b ) throws IOException {
+		buffer.put( ( byte ) b );
+		flushBuffer();
+	}
+
+	@Override
+	public void write( byte[] b, int off, int len ) throws IOException {
+		int remaining = len;
+		while ( remaining > 0 ) {
+			int toWrite = Math.min( buffer.remaining(), remaining );
+			buffer.put( b, off + ( len - remaining ), toWrite );
+			remaining -= toWrite;
+			flushBuffer();
+		}
+	}
+
+	private void flushBuffer() throws IOException {
+		buffer.flip();
+		while ( buffer.hasRemaining() ) {
+			channel.awaitWritable(); // Block until the channel is writable
+			channel.write( buffer );
+		}
+		buffer.compact();
+	}
+
+	@Override
+	public void flush() throws IOException {
+		flushBuffer();
+	}
+
+	@Override
+	public void close() throws IOException {
+		flush();
+		channel.close();
+	}
+}


### PR DESCRIPTION
# Release notes - BoxLang - 1.0.0-Beta14

### Bug

[BL-496](https://ortussolutions.atlassian.net/browse/BL-496) replace and replaceNoCase functions do not accept a callback

[BL-519](https://ortussolutions.atlassian.net/browse/BL-519) Query dereferencing is not working correctly: Column '1' does not exist in query

[BL-520](https://ortussolutions.atlassian.net/browse/BL-520) Run Class via URL

[BL-523](https://ortussolutions.atlassian.net/browse/BL-523) A class which uses inheritance, the metadata includes the inherited functions in itself and parent.

[BL-524](https://ortussolutions.atlassian.net/browse/BL-524) reFindNoCase\( "^\(f|x\)?test$", arguments.methodName \) fails with  Cannot invoke "String.length\(\)" because the return value of "java.util.regex.Matcher.group\(int\)" is null

[BL-525](https://ortussolutions.atlassian.net/browse/BL-525) lsParseDateTime errors when given locale and mask

[BL-526](https://ortussolutions.atlassian.net/browse/BL-526) dateformat incorrectly parsing date with leading 0's?

[BL-527](https://ortussolutions.atlassian.net/browse/BL-527) onMissingMethod is not firing if the execution of the method is from within the class

[BL-528](https://ortussolutions.atlassian.net/browse/BL-528) query dumps assume the value is simple and can explode with encodeForHTML\(\) can't do complex objects

[BL-530](https://ortussolutions.atlassian.net/browse/BL-530) Improve tracking of class in function box context

[BL-531](https://ortussolutions.atlassian.net/browse/BL-531) Difference of behavior with cfdirectory recurse = true not including path

[BL-532](https://ortussolutions.atlassian.net/browse/BL-532) super long strings cause compilation errors due to limitations in Java source code

[BL-533](https://ortussolutions.atlassian.net/browse/BL-533) Errors in miniserver when flushing large amounts of output to buffer

[BL-534](https://ortussolutions.atlassian.net/browse/BL-534) Missing !== operator

[BL-535](https://ortussolutions.atlassian.net/browse/BL-535) query cell assign erroring

[BL-537](https://ortussolutions.atlassian.net/browse/BL-537) Add onBifInvocation Interception Announcement to BIF invoke method

### Improvement

[BL-228](https://ortussolutions.atlassian.net/browse/BL-228) Consolidate/Rename "LS" Bifs and Move US-Centric ones to Compat

[BL-409](https://ortussolutions.atlassian.net/browse/BL-409) Member method cleanup

[BL-410](https://ortussolutions.atlassian.net/browse/BL-410) Improve REPL output of native Java arrays

[BL-541](https://ortussolutions.atlassian.net/browse/BL-541) Add "decimal" as a cast type

### New Feature

[BL-93](https://ortussolutions.atlassian.net/browse/BL-93) Create immutable query type

[BL-529](https://ortussolutions.atlassian.net/browse/BL-529) Announce the onBXDump whenever a dump is about to be rendered, to allow for external listeners to receive the dump

[BL-536](https://ortussolutions.atlassian.net/browse/BL-536) New server keys: executionCommand, executionArgs to assist with CLI tooling

[BL-538](https://ortussolutions.atlassian.net/browse/BL-538) New runtime inCLIMode\(\) method to tell you if the runtime was started via the runtime or something else

[BL-539](https://ortussolutions.atlassian.net/browse/BL-539) New server.cli key to provide you with all the CLI options used to run the runtime

[BL-540](https://ortussolutions.atlassian.net/browse/BL-540) Refactor the CLIOptions to it's own class and add a simple argument parser

[BL-496]: https://ortussolutions.atlassian.net/browse/BL-496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-519]: https://ortussolutions.atlassian.net/browse/BL-519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-520]: https://ortussolutions.atlassian.net/browse/BL-520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-523]: https://ortussolutions.atlassian.net/browse/BL-523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-524]: https://ortussolutions.atlassian.net/browse/BL-524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-525]: https://ortussolutions.atlassian.net/browse/BL-525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-526]: https://ortussolutions.atlassian.net/browse/BL-526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-527]: https://ortussolutions.atlassian.net/browse/BL-527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ