### PR TITLE
v1.0.0-Beta17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,7 @@ jobs:
       #   if: env.SNAPSHOT == 'false'
       #   run: |
       #     gradle publish --no-daemon --no-parallel
-      #     gradle publishToSonatype closeAndReleaseSonatypeStagingRepository
+      #     gradle publishAllPublicationsToCentralPortal
       #   env:
       #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       #     GPG_KEY: ${{ secrets.GPG_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,17 +159,17 @@ jobs:
           DEST_DIR: "boxlang-runtimes/${{ env.MODULE_ID }}/${{ env.VERSION }}"
 
       # Publish to Maven Central + Github ONLY on Beta/Final Releases
-      # - name: Publish Package (Maven+Github)
-      #   if: env.SNAPSHOT == 'false'
-      #   run: |
-      #     gradle publish --no-daemon --no-parallel
-      #     gradle publishAllPublicationsToCentralPortal
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     GPG_KEY: ${{ secrets.GPG_KEY }}
-      #     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
-      #     MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-      #     MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+      - name: Publish Package (Maven+Github)
+        if: env.SNAPSHOT == 'false'
+        run: |
+          gradle publish --no-daemon --no-parallel
+          gradle publishAllPublicationsToCentralPortal
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_KEY: ${{ secrets.GPG_KEY }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
 
       - name: Create Github Release
         uses: taiki-e/create-gh-release-action@v1.8.0

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import java.nio.file.StandardCopyOption
 import java.nio.file.Files
 import java.text.SimpleDateFormat
 import java.util.Date
-// https://docs.gradle.org/current/userguide/building_java_projects.html#sec:java_packaging 
+// https://docs.gradle.org/current/userguide/building_java_projects.html#sec:java_packaging
 plugins {
     id 'java'
 	// Apply the application plugin to add support for building a CLI application in Java.
@@ -192,9 +192,9 @@ publishing {
 					}
 				}
 				scm {
-					connection = 'scm:git:https://github.com/ortus-boxlang/boxlang.git'
-					developerConnection = 'scm:git:ssh://github.com/ortus-boxlang/boxlang.git'
-					url = 'https://github.com/ortus-boxlang/boxlang'
+					connection = 'scm:git:https://github.com/ortus-boxlang/boxlang-miniserver.git'
+					developerConnection = 'scm:git:ssh://github.com/ortus-boxlang/boxlang-miniserver.git'
+					url = 'https://github.com/ortus-boxlang/boxlang-miniserver'
 				}
 				developers{
 					developer {
@@ -265,7 +265,7 @@ publishing {
         }
 		maven {
 			name = "GitHubPackages"
-			url = "https://maven.pkg.github.com/ortus-boxlang/boxlang"
+			url = "https://maven.pkg.github.com/ortus-boxlang/boxlang-miniserver"
 			credentials {
 				username = System.getenv( "GITHUB_ACTOR" )
 				password = System.getenv( "GITHUB_TOKEN" )

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta16] - 2024-09-27
+
 ## [1.0.0-beta15] - 2024-09-20
 
 ## [1.0.0-beta14] - 2024-09-13
@@ -42,7 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded to Undertow latest due to security fix
 - First iteration of this module
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0-beta15...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0-beta16...HEAD
+
+[1.0.0-beta16]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0-beta15...v1.0.0-beta16
 
 [1.0.0-beta15]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0-beta14...v1.0.0-beta15
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Fri Sep 20 13:05:44 UTC 2024
-boxlangVersion=1.0.0-beta16
+#Fri Sep 27 20:18:53 UTC 2024
+boxlangVersion=1.0.0-beta17
 jdkVersion=21
-version=1.0.0-beta16
+version=1.0.0-beta17
 group=ortus.boxlang

--- a/src/main/java/ortus/boxlang/web/MiniServer.java
+++ b/src/main/java/ortus/boxlang/web/MiniServer.java
@@ -34,6 +34,8 @@ import io.undertow.server.handlers.resource.PathResourceManager;
 import io.undertow.server.handlers.resource.ResourceHandler;
 import io.undertow.server.handlers.resource.ResourceManager;
 import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.web.handlers.BLHandler;
 import ortus.boxlang.web.handlers.WebsocketHandler;
 import ortus.boxlang.web.handlers.WelcomeFileHandler;
@@ -122,7 +124,10 @@ public class MiniServer {
 		System.out.println( "+ Starting BoxLang Runtime..." );
 
 		// Startup the runtime
-		BoxRuntime			runtime			= BoxRuntime.getInstance( debug, configPath, serverHome );
+		BoxRuntime	runtime		= BoxRuntime.getInstance( debug, configPath, serverHome );
+		IStruct		versionInfo	= runtime.getVersionInfo();
+		System.out.println(
+		    "- BoxLang Version: " + versionInfo.getAsString( Key.of( "version" ) ) + " (Built On: " + versionInfo.getAsString( Key.of( "buildDate" ) ) + ")" );
 		Undertow.Builder	builder			= Undertow.builder();
 		ResourceManager		resourceManager	= new PathResourceManager( absWebRoot );
 

--- a/src/main/java/ortus/boxlang/web/MiniServer.java
+++ b/src/main/java/ortus/boxlang/web/MiniServer.java
@@ -73,7 +73,8 @@ public class MiniServer {
 		// Setup default values
 		int					port		= Integer.parseInt( envVars.getOrDefault( "BOXLANG_PORT", "8080" ) );
 		String				webRoot		= envVars.getOrDefault( "BOXLANG_WEBROOT", "" );
-		boolean				debug		= Boolean.parseBoolean( envVars.getOrDefault( "BOXLANG_DEBUG", "false" ) );
+		// DO NOT DEFAULT THIS.
+		Boolean				debug		= Boolean.parseBoolean( envVars.get( "BOXLANG_DEBUG" ) );
 		String				host		= envVars.getOrDefault( "BOXLANG_HOST", "localhost" );
 		String				configPath	= envVars.getOrDefault( "BOXLANG_CONFIG", null );
 		String				serverHome	= envVars.getOrDefault( "BOXLANG_HOME", null );
@@ -118,7 +119,9 @@ public class MiniServer {
 		System.out.println( "- Web Root: " + absWebRoot.toString() );
 		System.out.println( "- Host: " + host );
 		System.out.println( "- Port: " + port );
-		System.out.println( "- Debug: " + debug );
+		if ( debug != null ) {
+			System.out.println( "- Debug: " + debug );
+		}
 		System.out.println( "- Config Path: " + configPath );
 		System.out.println( "- Server Home: " + serverHome );
 		System.out.println( "+ Starting BoxLang Runtime..." );

--- a/src/main/java/ortus/boxlang/web/handlers/WebsocketHandler.java
+++ b/src/main/java/ortus/boxlang/web/handlers/WebsocketHandler.java
@@ -10,6 +10,10 @@ import io.undertow.websockets.WebSocketConnectionCallback;
 import io.undertow.websockets.WebSocketProtocolHandshakeHandler;
 import io.undertow.websockets.core.WebSocketChannel;
 import io.undertow.websockets.core.WebSockets;
+import io.undertow.websockets.core.protocol.Handshake;
+import io.undertow.websockets.core.protocol.version07.Hybi07Handshake;
+import io.undertow.websockets.core.protocol.version08.Hybi08Handshake;
+import io.undertow.websockets.core.protocol.version13.Hybi13Handshake;
 import io.undertow.websockets.spi.WebSocketHttpExchange;
 import ortus.boxlang.web.MiniServer;
 
@@ -20,7 +24,14 @@ public class WebsocketHandler extends PathHandler {
 
 	public WebsocketHandler( final HttpHandler next, String prefixPath ) {
 		super( next );
+
+		Set<Handshake> handshakes = new HashSet<>();
+		handshakes.add( new Hybi13Handshake( Set.of( "v12.stomp", "v11.stomp", "v10.stomp" ), false ) );
+		handshakes.add( new Hybi08Handshake( Set.of( "v12.stomp", "v11.stomp", "v10.stomp" ), false ) );
+		handshakes.add( new Hybi07Handshake( Set.of( "v12.stomp", "v11.stomp", "v10.stomp" ), false ) );
+
 		this.webSocketProtocolHandshakeHandler = new WebSocketProtocolHandshakeHandler(
+		    handshakes,
 		    new WebSocketConnectionCallback() {
 
 			    @Override


### PR DESCRIPTION
# Release notes - BoxLang - 1.0.0-Beta17

### Bug

[BL-608](https://ortussolutions.atlassian.net/browse/BL-608) Timeouts \(connection, idle\) for datasources needs to be in seconds and not in milliseconds to adhere to cfconfig

[BL-609](https://ortussolutions.atlassian.net/browse/BL-609) BoxLang resolvers do not allow class paths to have \`-\` in them.

### Improvement

[BL-607](https://ortussolutions.atlassian.net/browse/BL-607) Add version/build date to output of Miniserver startup

[BL-610](https://ortussolutions.atlassian.net/browse/BL-610) onSessionEnd needs application settings made available

[BL-611](https://ortussolutions.atlassian.net/browse/BL-611) Remove debugmode capture on miniserver, delegate to the core runtime.

### New Feature

[BL-605](https://ortussolutions.atlassian.net/browse/BL-605) MiniServer WebSocket handler

[BL-608]: https://ortussolutions.atlassian.net/browse/BL-608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-609]: https://ortussolutions.atlassian.net/browse/BL-609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-607]: https://ortussolutions.atlassian.net/browse/BL-607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-610]: https://ortussolutions.atlassian.net/browse/BL-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-611]: https://ortussolutions.atlassian.net/browse/BL-611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-605]: https://ortussolutions.atlassian.net/browse/BL-605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ