### PR TITLE
1.0.0-Beta18

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta17] - 2024-10-04
+
 ## [1.0.0-beta16] - 2024-09-27
 
 ## [1.0.0-beta15] - 2024-09-20
@@ -44,7 +46,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded to Undertow latest due to security fix
 - First iteration of this module
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0-beta16...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0-beta17...HEAD
+
+[1.0.0-beta17]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0-beta16...v1.0.0-beta17
 
 [1.0.0-beta16]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0-beta15...v1.0.0-beta16
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Fri Sep 27 20:18:53 UTC 2024
-boxlangVersion=1.0.0-beta17
+#Fri Oct 04 19:21:48 UTC 2024
+boxlangVersion=1.0.0-beta18
 jdkVersion=21
-version=1.0.0-beta17
+version=1.0.0-beta18
 group=ortus.boxlang

--- a/src/main/java/ortus/boxlang/web/MiniServer.java
+++ b/src/main/java/ortus/boxlang/web/MiniServer.java
@@ -61,20 +61,29 @@ import ortus.boxlang.web.handlers.WelcomeFileHandler;
  */
 public class MiniServer {
 
+	/**
+	 * Flag to indicate if the server is shutting down.
+	 */
 	public static boolean									shuttingDown	= false;
 
+	/**
+	 * The Websocket handler for the server.
+	 */
 	public static WebsocketHandler							websocketHandler;
 
-	private static final ThreadLocal<HttpServerExchange>	currentExchange	= new ThreadLocal<HttpServerExchange>();
+	/**
+	 * ThreadLocal to store the current HttpServerExchange.
+	 */
+	private static final ThreadLocal<HttpServerExchange>	currentExchange	= new ThreadLocal<>();
 
 	public static void main( String[] args ) {
 		Map<String, String>	envVars		= System.getenv();
 
-		// Setup default values
+		// Setup Defaults, and grab environment variables
 		int					port		= Integer.parseInt( envVars.getOrDefault( "BOXLANG_PORT", "8080" ) );
 		String				webRoot		= envVars.getOrDefault( "BOXLANG_WEBROOT", "" );
-		// DO NOT DEFAULT THIS.
-		Boolean				debug		= Boolean.parseBoolean( envVars.get( "BOXLANG_DEBUG" ) );
+		// We don't do this one, as it is done by the runtime itself.
+		Boolean				debug		= null;
 		String				host		= envVars.getOrDefault( "BOXLANG_HOST", "localhost" );
 		String				configPath	= envVars.getOrDefault( "BOXLANG_CONFIG", null );
 		String				serverHome	= envVars.getOrDefault( "BOXLANG_HOME", null );
@@ -116,25 +125,25 @@ public class MiniServer {
 		// Start the server
 		var sTime = System.currentTimeMillis();
 		System.out.println( "+ Starting BoxLang Server..." );
-		System.out.println( "- Web Root: " + absWebRoot.toString() );
-		System.out.println( "- Host: " + host );
-		System.out.println( "- Port: " + port );
-		if ( debug != null ) {
-			System.out.println( "- Debug: " + debug );
-		}
-		System.out.println( "- Config Path: " + configPath );
-		System.out.println( "- Server Home: " + serverHome );
+		System.out.println( "  - Web Root: " + absWebRoot.toString() );
+		System.out.println( "  - Host: " + host );
+		System.out.println( "  - Port: " + port );
+		System.out.println( "  - Debug: " + debug );
+		System.out.println( "  - Config Path: " + configPath );
+		System.out.println( "  - Server Home: " + serverHome );
 		System.out.println( "+ Starting BoxLang Runtime..." );
 
 		// Startup the runtime
 		BoxRuntime	runtime		= BoxRuntime.getInstance( debug, configPath, serverHome );
 		IStruct		versionInfo	= runtime.getVersionInfo();
 		System.out.println(
-		    "- BoxLang Version: " + versionInfo.getAsString( Key.of( "version" ) ) + " (Built On: " + versionInfo.getAsString( Key.of( "buildDate" ) ) + ")" );
+		    "  - BoxLang Version: " + versionInfo.getAsString( Key.of( "version" ) ) + " (Built On: "
+		        + versionInfo.getAsString( Key.of( "buildDate" ) )
+		        + ")" );
 		Undertow.Builder	builder			= Undertow.builder();
 		ResourceManager		resourceManager	= new PathResourceManager( absWebRoot );
 
-		System.out.println( "+ Runtime Started in " + ( System.currentTimeMillis() - sTime ) + "ms" );
+		System.out.println( "  - Runtime Started in " + ( System.currentTimeMillis() - sTime ) + "ms" );
 
 		HttpHandler httpHandler = new EncodingHandler(
 		    new ContentEncodingRepository().addEncodingHandler(
@@ -152,9 +161,9 @@ public class MiniServer {
 		        List.of( "index.bxm", "index.bxs", "index.cfm", "index.cfs", "index.htm", "index.html" )
 		    ) );
 
-		System.out.println( "+ WebSocket Server started" );
 		httpHandler			= new WebsocketHandler( httpHandler, "/ws" );
 		websocketHandler	= ( WebsocketHandler ) httpHandler;
+		System.out.println( "+ WebSocket Server started" );
 
 		final HttpHandler finalHttpHandler = httpHandler;
 		httpHandler = new HttpHandler() {
@@ -194,20 +203,37 @@ public class MiniServer {
 		} ) );
 
 		// Startup the server
-		System.out.println( "+ BoxLang MiniServer started in " + ( System.currentTimeMillis() - sTime ) + "ms" );
-		System.out.println( "+ BoxLang MiniServer started at: http://" + host + ":" + port );
+		System.out.println(
+		    "+ BoxLang MiniServer started in " + ( System.currentTimeMillis() - sTime ) + "ms" +
+		        " at: http://" + host + ":" + port
+		);
 		System.out.println( "Press Ctrl+C to stop the server." );
 		BLServer.start();
 	}
 
+	/**
+	 * Get the current HttpServerExchange for the thread.
+	 *
+	 * @return The current HttpServerExchange for the thread.
+	 */
 	public static HttpServerExchange getCurrentExchange() {
 		return currentExchange.get();
 	}
 
+	/**
+	 * Set the current HttpServerExchange for the thread.
+	 *
+	 * @param exchange
+	 */
 	public static void setCurrentExchange( HttpServerExchange exchange ) {
 		currentExchange.set( exchange );
 	}
 
+	/**
+	 * Get the WebsocketHandler for the server.
+	 *
+	 * @return The WebsocketHandler for the server.
+	 */
 	public static WebsocketHandler getWebsocketHandler() {
 		return websocketHandler;
 	}

--- a/src/main/java/ortus/boxlang/web/exchange/BoxHTTPUndertowExchange.java
+++ b/src/main/java/ortus/boxlang/web/exchange/BoxHTTPUndertowExchange.java
@@ -67,7 +67,7 @@ public class BoxHTTPUndertowExchange implements IBoxHTTPExchange {
 	/**
 	 * Request attributes
 	 */
-	private Map<String, Object>		attributes	= new HashMap<String, Object>();
+	private Map<String, Object>		attributes	= new HashMap<>();
 
 	/**
 	 * Undertow response channel
@@ -92,7 +92,7 @@ public class BoxHTTPUndertowExchange implements IBoxHTTPExchange {
 	/**
 	 * The list of file uploads
 	 */
-	List<FileUpload>				fileUploads	= new ArrayList<FileUpload>();
+	List<FileUpload>				fileUploads	= new ArrayList<>();
 
 	/**
 	 * Create a new BoxLang HTTP exchange for Undertow

--- a/src/main/java/ortus/boxlang/web/handlers/BLHandler.java
+++ b/src/main/java/ortus/boxlang/web/handlers/BLHandler.java
@@ -38,14 +38,32 @@ import ortus.boxlang.web.exchange.BoxHTTPUndertowExchange;
  */
 public class BLHandler implements HttpHandler {
 
+	/**
+	 * The pattern to match the path info
+	 */
 	static final Pattern	pattern	= Pattern.compile( "^(/.+?\\.cfml|/.+?\\.cf[cms]|.+?\\.bx[ms]{0,1})(/.*)?$" );
 
+	/**
+	 * The web root
+	 */
 	private String			webRoot;
 
+	/**
+	 * Create a new BLHandler
+	 *
+	 * @param webRoot The web root
+	 */
 	public BLHandler( String webRoot ) {
 		this.webRoot = webRoot;
 	}
 
+	/**
+	 * Handle the request
+	 *
+	 * @param exchange The HttpServerExchange
+	 *
+	 * @throws Exception If an error occurs
+	 */
 	@Override
 	public void handleRequest( io.undertow.server.HttpServerExchange exchange ) throws Exception {
 		if ( exchange.isInIoThread() ) {

--- a/src/main/java/ortus/boxlang/web/handlers/WebsocketHandler.java
+++ b/src/main/java/ortus/boxlang/web/handlers/WebsocketHandler.java
@@ -1,3 +1,20 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ortus.boxlang.web.handlers;
 
 import java.util.Collections;
@@ -17,11 +34,21 @@ import io.undertow.websockets.core.protocol.version13.Hybi13Handshake;
 import io.undertow.websockets.spi.WebSocketHttpExchange;
 import ortus.boxlang.web.MiniServer;
 
+/**
+ * The WebsocketHandler is a handler that handles WebSocket connections.
+ * Based on Undertow.
+ */
 public class WebsocketHandler extends PathHandler {
 
 	private final Set<WebSocketChannel>				connections	= Collections.synchronizedSet( new HashSet<>() );
 	private final WebSocketProtocolHandshakeHandler	webSocketProtocolHandshakeHandler;
 
+	/**
+	 * Create a new WebsocketHandler.
+	 *
+	 * @param next       The next handler in the chain
+	 * @param prefixPath The prefix path
+	 */
 	public WebsocketHandler( final HttpHandler next, String prefixPath ) {
 		super( next );
 
@@ -62,6 +89,12 @@ public class WebsocketHandler extends PathHandler {
 		return connections;
 	}
 
+	/**
+	 * Send a message to a WebSocket channel.
+	 *
+	 * @param channel The WebSocket channel
+	 * @param message The message to send
+	 */
 	public void sendMessage( WebSocketChannel channel, String message ) {
 		if ( channel == null || !channel.isOpen() ) {
 			return;
@@ -69,6 +102,11 @@ public class WebsocketHandler extends PathHandler {
 		WebSockets.sendText( message, channel, null );
 	}
 
+	/**
+	 * Broadcast a message to all open connections.
+	 *
+	 * @param message The message to broadcast
+	 */
 	public void broadcastMessage( String message ) {
 		// Iterate over all open connections and send the message
 		for ( WebSocketChannel channel : connections ) {

--- a/src/main/java/ortus/boxlang/web/handlers/WebsocketReceiveListener.java
+++ b/src/main/java/ortus/boxlang/web/handlers/WebsocketReceiveListener.java
@@ -1,3 +1,20 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ortus.boxlang.web.handlers;
 
 import java.io.IOException;
@@ -56,8 +73,10 @@ public class WebsocketReceiveListener extends AbstractReceiveListener {
 
 	/**
 	 * constructor
-	 * 
+	 *
 	 * @param exchange the HttpServerExchange
+	 * @param next     the HttpHandler
+	 * @param channel  the WebSocketChannel
 	 */
 	public WebsocketReceiveListener( HttpServerExchange exchange, HttpHandler next, WebSocketChannel channel ) {
 		this.exchange	= exchange;
@@ -69,7 +88,7 @@ public class WebsocketReceiveListener extends AbstractReceiveListener {
 
 	/**
 	 * onClose method
-	 * 
+	 *
 	 * @param channel the WebSocketChannel
 	 */
 	public void onClose( AbstractFramedChannel channel ) {
@@ -78,10 +97,10 @@ public class WebsocketReceiveListener extends AbstractReceiveListener {
 
 	/**
 	 * onFullTextMessage method
-	 * 
+	 *
 	 * @param channel the WebSocketChannel
 	 * @param message the BufferedTextMessage
-	 * 
+	 *
 	 * @throws IOException
 	 */
 	@Override
@@ -90,6 +109,14 @@ public class WebsocketReceiveListener extends AbstractReceiveListener {
 		dispatchRequest( "onFullTextMessage", List.of( message, channel ) );
 	}
 
+	/**
+	 * onFullBinaryMessage method
+	 *
+	 * @param channel the WebSocketChannel
+	 * @param message the BufferedBinaryMessage
+	 *
+	 * @throws IOException
+	 */
 	protected void onFullBinaryMessage( final WebSocketChannel channel, BufferedBinaryMessage message ) throws IOException {
 		// turn the message into a string
 		Pooled<ByteBuffer[]>	pbb	= message.getData();
@@ -103,6 +130,12 @@ public class WebsocketReceiveListener extends AbstractReceiveListener {
 		message.getData().free();
 	}
 
+	/**
+	 * Dispatch a request to the WebSocket.cfc
+	 *
+	 * @param method         the method to call
+	 * @param requestDetails the request details
+	 */
 	public void dispatchRequest( String method, List<Object> requestDetails ) {
 		// If the server is shutting down, there's nothign to do.
 		if ( MiniServer.shuttingDown ) {

--- a/src/main/java/ortus/boxlang/web/handlers/WelcomeFileHandler.java
+++ b/src/main/java/ortus/boxlang/web/handlers/WelcomeFileHandler.java
@@ -1,3 +1,20 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ortus.boxlang.web.handlers;
 
 import java.io.IOException;
@@ -9,18 +26,35 @@ import io.undertow.server.handlers.resource.Resource;
 import io.undertow.server.handlers.resource.ResourceManager;
 import io.undertow.util.CanonicalPathUtils;
 
+/**
+ * The WelcomeFileHandler is an Undertow HttpHandler that serves welcome files.
+ */
 public class WelcomeFileHandler implements HttpHandler {
 
 	private final HttpHandler		next;
 	private final ResourceManager	resourceManager;
 	private List<String>			welcomeFiles;
 
+	/**
+	 * Create a new WelcomeFileHandler
+	 *
+	 * @param next            The next HttpHandler
+	 * @param resourceManager The ResourceManager
+	 * @param welcomeFiles    The list of welcome files
+	 */
 	public WelcomeFileHandler( final HttpHandler next, ResourceManager resourceManager, List<String> welcomeFiles ) {
 		this.next				= next;
 		this.resourceManager	= resourceManager;
 		this.welcomeFiles		= welcomeFiles;
 	}
 
+	/**
+	 * Handle the request
+	 *
+	 * @param exchange The HttpServerExchange
+	 *
+	 * @throws Exception
+	 */
 	@Override
 	public void handleRequest( final HttpServerExchange exchange ) throws Exception {
 		Resource resource = resourceManager.getResource( canonicalize( exchange.getRelativePath() ) );
@@ -37,9 +71,20 @@ public class WelcomeFileHandler implements HttpHandler {
 		}
 
 		next.handleRequest( exchange );
-
 	}
 
+	/**
+	 * Get the index files
+	 *
+	 * @param exchange        The HttpServerExchange
+	 * @param resourceManager The ResourceManager
+	 * @param base            The base path
+	 * @param possible        The list of possible index files
+	 *
+	 * @return
+	 *
+	 * @throws IOException
+	 */
 	private Resource getIndexFiles( HttpServerExchange exchange, ResourceManager resourceManager, final String base,
 	    List<String> possible ) throws IOException {
 		if ( possible == null ) {
@@ -60,6 +105,13 @@ public class WelcomeFileHandler implements HttpHandler {
 		return null;
 	}
 
+	/**
+	 * Canonicalize the path
+	 *
+	 * @param s The path
+	 *
+	 * @return The canonicalized path
+	 */
 	private String canonicalize( String s ) {
 		return CanonicalPathUtils.canonicalize( s );
 	}

--- a/src/main/java/ortus/boxlang/web/util/BlockingBufferedOutputStream.java
+++ b/src/main/java/ortus/boxlang/web/util/BlockingBufferedOutputStream.java
@@ -1,3 +1,20 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ortus.boxlang.web.util;
 
 import java.io.IOException;
@@ -6,22 +23,39 @@ import java.nio.ByteBuffer;
 
 import org.xnio.channels.StreamSinkChannel;
 
+/**
+ * A blocking buffered output stream that writes to a StreamSinkChannel.
+ * We do not use the built-in BufferedOutputStream because it does not block when the channel is not writable.
+ */
 public class BlockingBufferedOutputStream extends OutputStream {
 
 	private final StreamSinkChannel	channel;
 	private final ByteBuffer		buffer;
 
+	/**
+	 * Create a new BlockingBufferedOutputStream
+	 *
+	 * @param channel The StreamSinkChannel
+	 */
 	public BlockingBufferedOutputStream( StreamSinkChannel channel ) {
 		this.channel	= channel;
 		this.buffer		= ByteBuffer.allocate( 1024 );
 	}
 
+	/**
+	 * Create a new BlockingBufferedOutputStream
+	 */
 	@Override
 	public void write( int b ) throws IOException {
 		buffer.put( ( byte ) b );
 		flushBuffer();
 	}
 
+	/**
+	 * Write a byte array to the output stream
+	 *
+	 * @param b The byte array
+	 */
 	@Override
 	public void write( byte[] b, int off, int len ) throws IOException {
 		int remaining = len;
@@ -33,6 +67,11 @@ public class BlockingBufferedOutputStream extends OutputStream {
 		}
 	}
 
+	/**
+	 * Flush the buffer
+	 *
+	 * @throws IOException If an error occurs
+	 */
 	private void flushBuffer() throws IOException {
 		if ( channel == null ) {
 			buffer.clear();
@@ -46,11 +85,21 @@ public class BlockingBufferedOutputStream extends OutputStream {
 		buffer.compact();
 	}
 
+	/**
+	 * Flush the output stream
+	 *
+	 * @throws IOException If an error occurs
+	 */
 	@Override
 	public void flush() throws IOException {
 		flushBuffer();
 	}
 
+	/**
+	 * Close the output stream
+	 *
+	 * @throws IOException If an error occurs
+	 */
 	@Override
 	public void close() throws IOException {
 		flush();


### PR DESCRIPTION
# Release notes - BoxLang - 1.0.0-Beta18

### New Feature

[BL-617](https://ortussolutions.atlassian.net/browse/BL-617) arrayFind, arrayFindNoCase value closures, accept the value and now the index of the item as the second param

[BL-626](https://ortussolutions.atlassian.net/browse/BL-626) New configuration: validBoxLangTemplates to determine which templates the Runnable Loader can process

[BL-627](https://ortussolutions.atlassian.net/browse/BL-627) New configuration: validClassExtensions to determine which class extensions to work with

[BL-629](https://ortussolutions.atlassian.net/browse/BL-629) New security configuration section for disallowing: BIFS, Components, Imports

[BL-630](https://ortussolutions.atlassian.net/browse/BL-630) Internal refactor to make the class locator and resolvers have a life-cycle based on the runtime and not alone

### Bug

[BL-614](https://ortussolutions.atlassian.net/browse/BL-614) Import nested classes

[BL-615](https://ortussolutions.atlassian.net/browse/BL-615) Java static funcitons not behaving as expected

[BL-616](https://ortussolutions.atlassian.net/browse/BL-616) array.find does not use cf rules to convert result of predicate to boolean

[BL-619](https://ortussolutions.atlassian.net/browse/BL-619) QueryColumnType doesn't handle "idstamp" \(mssql\)

[BL-620](https://ortussolutions.atlassian.net/browse/BL-620) static scope in application.cfc not initialized before psuedoConstructor runs

[BL-624](https://ortussolutions.atlassian.net/browse/BL-624) Auto-escaping of \{\} in regex needs to ignore already-escaped braces

[BL-625](https://ortussolutions.atlassian.net/browse/BL-625) Instead of removing special chars from Java FQN, replace with \_\_ to avoid conflicts

[BL-628](https://ortussolutions.atlassian.net/browse/BL-628) Tag expressions not parsing inside template island inside braces

[BL-631](https://ortussolutions.atlassian.net/browse/BL-631) duplicate\(\) doesn't work on empty structs

[BL-633](https://ortussolutions.atlassian.net/browse/BL-633) randrange\(\) not inclusive of upper bound

[BL-634](https://ortussolutions.atlassian.net/browse/BL-634) array.find - can't cast closure to string

### Improvement

[BL-611](https://ortussolutions.atlassian.net/browse/BL-611) Remove debugmode capture on miniserver, delegate to the core runtime.

[BL-622](https://ortussolutions.atlassian.net/browse/BL-622) Consolidate CastAttempt and Attempt into a hierarchy

[BL-623](https://ortussolutions.atlassian.net/browse/BL-623) New DynamicFunction type that can be used to generate dynamic BoxLang functions using Java Lambda proxies. Great for code generation

[BL-617]: https://ortussolutions.atlassian.net/browse/BL-617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-626]: https://ortussolutions.atlassian.net/browse/BL-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-627]: https://ortussolutions.atlassian.net/browse/BL-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-629]: https://ortussolutions.atlassian.net/browse/BL-629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-630]: https://ortussolutions.atlassian.net/browse/BL-630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-614]: https://ortussolutions.atlassian.net/browse/BL-614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-615]: https://ortussolutions.atlassian.net/browse/BL-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-616]: https://ortussolutions.atlassian.net/browse/BL-616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ