### PR TITLE
1.0.0-Beta19

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta18] - 2024-10-11
+
 ## [1.0.0-beta17] - 2024-10-04
 
 ## [1.0.0-beta16] - 2024-09-27
@@ -46,7 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded to Undertow latest due to security fix
 - First iteration of this module
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0-beta17...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0-beta18...HEAD
+
+[1.0.0-beta18]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0-beta17...v1.0.0-beta18
 
 [1.0.0-beta17]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0-beta16...v1.0.0-beta17
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Fri Oct 04 19:21:48 UTC 2024
-boxlangVersion=1.0.0-beta18
+#Fri Oct 11 15:36:27 UTC 2024
+boxlangVersion=1.0.0-beta19
 jdkVersion=21
-version=1.0.0-beta18
+version=1.0.0-beta19
 group=ortus.boxlang

--- a/src/main/java/ortus/boxlang/web/handlers/WebsocketHandler.java
+++ b/src/main/java/ortus/boxlang/web/handlers/WebsocketHandler.java
@@ -99,7 +99,10 @@ public class WebsocketHandler extends PathHandler {
 		if ( channel == null || !channel.isOpen() ) {
 			return;
 		}
-		WebSockets.sendText( message, channel, null );
+		// I'm not clear if Undertow handles this, but just to be safe only send one message to a channel at once to avoid threading issues
+		synchronized ( channel ) {
+			WebSockets.sendText( message, channel, null );
+		}
 	}
 
 	/**


### PR DESCRIPTION
# Release notes - BoxLang - 1.0.0-Beta19

### Bug

[BL-635](https://ortussolutions.atlassian.net/browse/BL-635) boxlang invokes private onApplicationStart

[BL-636](https://ortussolutions.atlassian.net/browse/BL-636) expandPath does not preserve file system case

[BL-639](https://ortussolutions.atlassian.net/browse/BL-639) cfml2wddx action missing

[BL-642](https://ortussolutions.atlassian.net/browse/BL-642) deserializeJSON not handling white space / control characters

[BL-645](https://ortussolutions.atlassian.net/browse/BL-645) Update parser to allow for \`@module\` notations on imports and \`new\` operators

[BL-649](https://ortussolutions.atlassian.net/browse/BL-649) listFind\(\) and listFindNoCase\(\) are allowing partial matches

[BL-651](https://ortussolutions.atlassian.net/browse/BL-651) Can't dump null in console

[BL-659](https://ortussolutions.atlassian.net/browse/BL-659)  Cannot invoke "java.lang.CharSequence.length\(\)" because "this.text" is null

### Improvement

[BL-328](https://ortussolutions.atlassian.net/browse/BL-328) Move CFID to compat module

[BL-612](https://ortussolutions.atlassian.net/browse/BL-612) Add STOMP subprotocols in miniserver

[BL-637](https://ortussolutions.atlassian.net/browse/BL-637) Have servlet runtime return actual pagecontext object instead of fake

[BL-644](https://ortussolutions.atlassian.net/browse/BL-644) Update the allowedFileOperationExtensions and disallowedFileOperationExtensions to the security block

[BL-650](https://ortussolutions.atlassian.net/browse/BL-650) Allow casting to array of primitive types

[BL-652](https://ortussolutions.atlassian.net/browse/BL-652) Improve exception when trying to invoke null as a function

[BL-654](https://ortussolutions.atlassian.net/browse/BL-654) Get ColdBox Loading via ASM

[BL-655](https://ortussolutions.atlassian.net/browse/BL-655) Improve logic surrounding loading of pre-compiled source files

[BL-660](https://ortussolutions.atlassian.net/browse/BL-660) added a \`isCommitted\(\)\` to the PageContext to match the servlet response to assist when doing resets without exceptions

[BL-661](https://ortussolutions.atlassian.net/browse/BL-661) StopGaps and config from cfconfig.json to boxlang.json

[BL-662](https://ortussolutions.atlassian.net/browse/BL-662) NotImplemented updated to check if it's a string and if empty, then ignore it to provide leeway

[BL-666](https://ortussolutions.atlassian.net/browse/BL-666) Rename default sessions cache to \`bxSessions\` to create the \`bx\` prefix standards. Add configuration to boxlang.json

### New Feature

[BL-232](https://ortussolutions.atlassian.net/browse/BL-232) Star-import for boxlang classes

[BL-646](https://ortussolutions.atlassian.net/browse/BL-646) Ability to import/create BoxLang classes from modules via direct \`@\{moduleName\}\` notation.

[BL-647](https://ortussolutions.atlassian.net/browse/BL-647) Ability to import create java classes from modules explicitly using the \`@\`notation

[BL-648](https://ortussolutions.atlassian.net/browse/BL-648) Import Definitions now support module addressing for simple, wildcard and aliases

[BL-653](https://ortussolutions.atlassian.net/browse/BL-653) Java wildcard imports from loaded jars

[BL-657](https://ortussolutions.atlassian.net/browse/BL-657) JavaResolver module targeted resolution

[BL-658](https://ortussolutions.atlassian.net/browse/BL-658) MIgrate AST Capture to it's own experimental flag

[BL-667](https://ortussolutions.atlassian.net/browse/BL-667) ASMBoxPiler to do direct java bytecode creation

[BL-635]: https://ortussolutions.atlassian.net/browse/BL-635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-636]: https://ortussolutions.atlassian.net/browse/BL-636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-639]: https://ortussolutions.atlassian.net/browse/BL-639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-642]: https://ortussolutions.atlassian.net/browse/BL-642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-645]: https://ortussolutions.atlassian.net/browse/BL-645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-649]: https://ortussolutions.atlassian.net/browse/BL-649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-651]: https://ortussolutions.atlassian.net/browse/BL-651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-659]: https://ortussolutions.atlassian.net/browse/BL-659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-328]: https://ortussolutions.atlassian.net/browse/BL-328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ