### PR TITLE
Version bump

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta22] - 2024-11-15
+
 ## [1.0.0-beta21] - 2024-11-01
 
 ## [1.0.0-beta20] - 2024-10-25
@@ -54,7 +56,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded to Undertow latest due to security fix
 - First iteration of this module
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0-beta21...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0-beta22...HEAD
+
+[1.0.0-beta22]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0-beta21...v1.0.0-beta22
 
 [1.0.0-beta21]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0-beta20...v1.0.0-beta21
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Fri Nov 01 20:52:59 UTC 2024
-boxlangVersion=1.0.0-beta22
+#Fri Nov 15 22:21:21 UTC 2024
+boxlangVersion=1.0.0-beta23
 jdkVersion=21
-version=1.0.0-beta22
+version=1.0.0-beta23
 group=ortus.boxlang


### PR DESCRIPTION
# Release notes - BoxLang - 1.0.0-Beta23

### Improvement

[BL-769](https://ortussolutions.atlassian.net/browse/BL-769) dump default to console output when in scripting context

[BL-770](https://ortussolutions.atlassian.net/browse/BL-770) avoid date parsing in len\(\) BIF

### Bug

[BL-761](https://ortussolutions.atlassian.net/browse/BL-761) Error when using abort in cfdump tag

[BL-763](https://ortussolutions.atlassian.net/browse/BL-763) whitespace management handle no content-type response header set yet

[BL-765](https://ortussolutions.atlassian.net/browse/BL-765) Difference of behaviour for handing arguments passed by position vs named

[BL-772](https://ortussolutions.atlassian.net/browse/BL-772) dsn key for jdbc drivers was not being used correctly as per cfconfig and replacements and producing invalid jdbc urls

[BL-774](https://ortussolutions.atlassian.net/browse/BL-774) Improve DateTimeCaster/DateTime instantiation performance with Strings

[BL-775](https://ortussolutions.atlassian.net/browse/BL-775) onSessionStart\(\) can cause endless recursion

[BL-776](https://ortussolutions.atlassian.net/browse/BL-776) debugmode flag in boxlang.json doesn't seem to be getting used

[BL-778](https://ortussolutions.atlassian.net/browse/BL-778) reconfigure debug mode doesn't work in a servlet

[BL-779](https://ortussolutions.atlassian.net/browse/BL-779) Logging interceptor is recreating appenders and loggers and discarding them on each log message, this is inefficient and a bottleneck under stress

[BL-780](https://ortussolutions.atlassian.net/browse/BL-780) writelog and log components where missing the \`application\` boolean argument

### New Feature

[BL-750](https://ortussolutions.atlassian.net/browse/BL-750) Component in BX for modules

[BL-768](https://ortussolutions.atlassian.net/browse/BL-768) ModuleService check the "boxlang" version to make sure the module is compatible or not

[BL-771](https://ortussolutions.atlassian.net/browse/BL-771) Generic JDBC Driver add a default URL delimiter, since some DBs are different

[BL-777](https://ortussolutions.atlassian.net/browse/BL-777) new getSemver\(\) bif to build or parse semvers and return a Semver object

### Story

[BL-116](https://ortussolutions.atlassian.net/browse/BL-116) Implement unfinished query options

[BL-769]: https://ortussolutions.atlassian.net/browse/BL-769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-770]: https://ortussolutions.atlassian.net/browse/BL-770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-761]: https://ortussolutions.atlassian.net/browse/BL-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-763]: https://ortussolutions.atlassian.net/browse/BL-763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-765]: https://ortussolutions.atlassian.net/browse/BL-765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-772]: https://ortussolutions.atlassian.net/browse/BL-772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-774]: https://ortussolutions.atlassian.net/browse/BL-774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-775]: https://ortussolutions.atlassian.net/browse/BL-775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-776]: https://ortussolutions.atlassian.net/browse/BL-776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ