### PR TITLE
versin bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,7 +246,7 @@ jobs:
           then
             gradle bumpPatchVersion --stacktrace --console=plain
           else
-            gradle bumpRCVersion --stacktrace --console=plain
+            gradle bumpMinorVersion --stacktrace --console=plain
           fi
           git pull
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ sourceCompatibility = jdkVersion
 targetCompatibility = jdkVersion
 ext {
 	buildID = System.getenv( 'BUILD_ID' ) ?: '0'
-	branch = System.getenv( 'BRANCH' ) ?: 'main'
+	branch = System.getenv( 'BRANCH' ) ?: 'development'
 }
 
 if (branch == 'development') {

--- a/build.gradle
+++ b/build.gradle
@@ -401,9 +401,9 @@ project.ext.bumpVersion = {
 	if( patch ){
 		newVersion = "${versionParts[ 0 ]}.${versionParts[ 1 ]}.${newPathVersion}"
 	} else if( minor ){
-		newVersion = "${versionParts[ 0 ]}.${newPathVersion}.${versionParts[ 2 ]}"
+		newVersion = "${versionParts[ 0 ]}.${newPathVersion}.0"
 	} else if( major ){
-		newVersion = "${newPathVersion}.${versionParts[ 1 ]}.${versionParts[ 2 ]}"
+		newVersion = "${newPathVersion}.0.0"
 	} else if( beta ){
 		// Get's the -betaX version.
 		def betaString = currentVersion.split( '-' )[ 1 ]

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### New Features
+
+- [BL-1365](https://ortussolutions.atlassian.net/browse/BL-1365) Add parse\(\) helper methods directly to runtime which returns parse result
+- [BL-1388](https://ortussolutions.atlassian.net/browse/BL-1388) new security configuration item: populateServerSystemScope that can allow or not the population of the server.system scope or not
+
+### Improvements
+
+- [BL-1333](https://ortussolutions.atlassian.net/browse/BL-1333) Create links to BoxLang modules
+- [BL-1351](https://ortussolutions.atlassian.net/browse/BL-1351) match getHTTPTimeString\(\) and default time to now
+- [BL-1358](https://ortussolutions.atlassian.net/browse/BL-1358) Work harder to return partial AST on invalid parse
+- [BL-1363](https://ortussolutions.atlassian.net/browse/BL-1363) Error executing dump template \[/dump/html/BoxClass.bxm\]
+- [BL-1375](https://ortussolutions.atlassian.net/browse/BL-1375) Compat - Move Legacy Date Format Interception to Module-Specific Interception Point
+- [BL-1381](https://ortussolutions.atlassian.net/browse/BL-1381) allow box class to be looped over as collection
+- [BL-1382](https://ortussolutions.atlassian.net/browse/BL-1382) Rework event bus interceptors to accelerate during executions
+- [BL-1383](https://ortussolutions.atlassian.net/browse/BL-1383) Compat - Allow handling of decimals where timespan is used
+- [BL-1387](https://ortussolutions.atlassian.net/browse/BL-1387) Allow Numeric ApplicationTimeout assignment to to be decimal
+
+### Bugs
+
+- [BL-1354](https://ortussolutions.atlassian.net/browse/BL-1354) BoxLang date time not accepted by JDBC as a date object
+- [BL-1359](https://ortussolutions.atlassian.net/browse/BL-1359) contracting path doesn't work if casing of mapping doesn't match casing of abs path
+- [BL-1366](https://ortussolutions.atlassian.net/browse/BL-1366) sessionInvalidate\(\) "Cannot invoke String.length\(\) because "s" is null"
+- [BL-1370](https://ortussolutions.atlassian.net/browse/BL-1370) Some methods not found in java interop
+- [BL-1372](https://ortussolutions.atlassian.net/browse/BL-1372) string functions accepting null
+- [BL-1374](https://ortussolutions.atlassian.net/browse/BL-1374) onMissingTemplate event mystyped as missingtemplate
+- [BL-1377](https://ortussolutions.atlassian.net/browse/BL-1377) fileExists\(\) not working with relative paths
+- [BL-1378](https://ortussolutions.atlassian.net/browse/BL-1378) optional capture groups throw NPE in reReplace\(\)
+- [BL-1379](https://ortussolutions.atlassian.net/browse/BL-1379) array length incorrect for xml nodes
+- [BL-1384](https://ortussolutions.atlassian.net/browse/BL-1384) Numeric Session Timeout Values Should Be Duration of Days  not Seconds
+
 ## [1.0.0] - 2025-04-30
 
 [Unreleased]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0...HEAD

--- a/changelog.md
+++ b/changelog.md
@@ -8,3 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * * *
 
 ## [Unreleased]
+
+## [1.0.0] - 2025-04-30
+
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0...HEAD
+
+[1.0.0]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/e31fe4ded229e36b940fea08bef9239588599479...v1.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Wed Mar 05 03:49:52 UTC 2025
-boxlangVersion=1.0.0
+#Wed Apr 30 02:58:06 UTC 2025
+boxlangVersion=1.1.0
 jdkVersion=21
-version=1.0.0
+version=1.1.0
 group=ortus.boxlang


### PR DESCRIPTION
### New Features

- [BL-1365](https://ortussolutions.atlassian.net/browse/BL-1365) Add parse\(\) helper methods directly to runtime which returns parse result
- [BL-1388](https://ortussolutions.atlassian.net/browse/BL-1388) new security configuration item: populateServerSystemScope that can allow or not the population of the server.system scope or not

### Improvements

- [BL-1333](https://ortussolutions.atlassian.net/browse/BL-1333) Create links to BoxLang modules
- [BL-1351](https://ortussolutions.atlassian.net/browse/BL-1351) match getHTTPTimeString\(\) and default time to now
- [BL-1358](https://ortussolutions.atlassian.net/browse/BL-1358) Work harder to return partial AST on invalid parse
- [BL-1363](https://ortussolutions.atlassian.net/browse/BL-1363) Error executing dump template \[/dump/html/BoxClass.bxm\]
- [BL-1375](https://ortussolutions.atlassian.net/browse/BL-1375) Compat - Move Legacy Date Format Interception to Module-Specific Interception Point
- [BL-1381](https://ortussolutions.atlassian.net/browse/BL-1381) allow box class to be looped over as collection
- [BL-1382](https://ortussolutions.atlassian.net/browse/BL-1382) Rework event bus interceptors to accelerate during executions
- [BL-1383](https://ortussolutions.atlassian.net/browse/BL-1383) Compat - Allow handling of decimals where timespan is used
- [BL-1387](https://ortussolutions.atlassian.net/browse/BL-1387) Allow Numeric ApplicationTimeout assignment to to be decimal

### Bugs

- [BL-1354](https://ortussolutions.atlassian.net/browse/BL-1354) BoxLang date time not accepted by JDBC as a date object
- [BL-1359](https://ortussolutions.atlassian.net/browse/BL-1359) contracting path doesn't work if casing of mapping doesn't match casing of abs path
- [BL-1366](https://ortussolutions.atlassian.net/browse/BL-1366) sessionInvalidate\(\) "Cannot invoke String.length\(\) because "s" is null"
- [BL-1370](https://ortussolutions.atlassian.net/browse/BL-1370) Some methods not found in java interop
- [BL-1372](https://ortussolutions.atlassian.net/browse/BL-1372) string functions accepting null
- [BL-1374](https://ortussolutions.atlassian.net/browse/BL-1374) onMissingTemplate event mystyped as missingtemplate
- [BL-1377](https://ortussolutions.atlassian.net/browse/BL-1377) fileExists\(\) not working with relative paths
- [BL-1378](https://ortussolutions.atlassian.net/browse/BL-1378) optional capture groups throw NPE in reReplace\(\)
- [BL-1379](https://ortussolutions.atlassian.net/browse/BL-1379) array length incorrect for xml nodes
- [BL-1384](https://ortussolutions.atlassian.net/browse/BL-1384) Numeric Session Timeout Values Should Be Duration of Days  not Seconds

[BL-1365]: https://ortussolutions.atlassian.net/browse/BL-1365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1388]: https://ortussolutions.atlassian.net/browse/BL-1388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1333]: https://ortussolutions.atlassian.net/browse/BL-1333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1351]: https://ortussolutions.atlassian.net/browse/BL-1351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1358]: https://ortussolutions.atlassian.net/browse/BL-1358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1363]: https://ortussolutions.atlassian.net/browse/BL-1363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1375]: https://ortussolutions.atlassian.net/browse/BL-1375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1381]: https://ortussolutions.atlassian.net/browse/BL-1381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1382]: https://ortussolutions.atlassian.net/browse/BL-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ