### PR TITLE
v1.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ bin/**
 grapher/**
 /libs/
 src/test/resources/libs/
+/wwwServerHome
+/www

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,16 @@
 		},
 		{
 			"type": "java",
+			"name": "MiniServer-Help",
+			"request": "launch",
+			"mainClass": "ortus.boxlang.web.MiniServer",
+			"projectName": "boxlang-miniserver",
+			"args": [
+				"--help"
+			]
+		},
+		{
+			"type": "java",
 			"name": "MiniServer-TestWWW",
 			"request": "launch",
 			"mainClass": "ortus.boxlang.web.MiniServer",

--- a/build.gradle
+++ b/build.gradle
@@ -166,6 +166,13 @@ task createDistributionFile( type: Zip ){
 			Files.copy( file( "build/distributions/boxlang-miniserver-${version}.jar.md5" ).toPath(), file( "build/evergreen/boxlang-miniserver-snapshot.jar.md5" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
 	    } else {
 	        Files.copy( file( "build/distributions/boxlang-miniserver-${version}.zip" ).toPath(), file( "build/evergreen/boxlang-miniserver-latest.zip" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+	        Files.copy( file( "build/distributions/boxlang-miniserver-${version}.jar" ).toPath(), file( "build/evergreen/boxlang-miniserver-latest.jar" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+	        // Copy checksums
+	        Files.copy( file( "build/distributions/boxlang-miniserver-${version}.zip.sha-256" ).toPath(), file( "build/evergreen/boxlang-miniserver-latest.zip.sha-256" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+			Files.copy( file( "build/distributions/boxlang-miniserver-${version}.zip.md5" ).toPath(), file( "build/evergreen/boxlang-miniserver-latest.zip.md5" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+			Files.copy( file( "build/distributions/boxlang-miniserver-${version}.jar.sha-256" ).toPath(), file( "build/evergreen/boxlang-miniserver-latest.jar.sha-256" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+			Files.copy( file( "build/distributions/boxlang-miniserver-${version}.jar.md5" ).toPath(), file( "build/evergreen/boxlang-miniserver-latest.jar.md5" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+			
 	    }
 
 		println "+ Distribution file has been created"

--- a/build.gradle
+++ b/build.gradle
@@ -144,20 +144,51 @@ task createDistributionFile( type: Zip ){
 	}
 	archiveFileName = "boxlang-miniserver-${version}.zip"
 	doLast {
-    Files.copy( file( "build/libs/boxlang-miniserver-${version}-javadoc.jar" ).toPath(), file( "build/distributions/boxlang-miniserver-${version}-javadoc.jar" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
 
-    file( "build/evergreen" ).mkdirs()
-    if( branch == 'development' ){
-        Files.copy( file( "build/distributions/boxlang-miniserver-${version}.zip" ).toPath(), file( "build/evergreen/boxlang-miniserver-snapshot.zip" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
-        Files.copy( file( "build/distributions/boxlang-miniserver-${version}.jar" ).toPath(), file( "build/evergreen/boxlang-miniserver-snapshot.jar" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
-    } else {
-        Files.copy( file( "build/distributions/boxlang-miniserver-${version}.zip" ).toPath(), file( "build/evergreen/boxlang-miniserver-latest.zip" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
-    }
+		// Generate checksums for all zip and jar files in distributions folder
+		file( "build/distributions" ).listFiles().each { file ->
+			if ( file.name.endsWith( '.zip' ) || file.name.endsWith( '.jar' ) ) {
+				generateChecksum( file, 'SHA-256' )
+				generateChecksum( file, 'MD5' )
+			}
+		}
+			
+	    Files.copy( file( "build/libs/boxlang-miniserver-${version}-javadoc.jar" ).toPath(), file( "build/distributions/boxlang-miniserver-${version}-javadoc.jar" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+
+	    file( "build/evergreen" ).mkdirs()
+	    if( branch == 'development' ){
+	        Files.copy( file( "build/distributions/boxlang-miniserver-${version}.zip" ).toPath(), file( "build/evergreen/boxlang-miniserver-snapshot.zip" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+	        Files.copy( file( "build/distributions/boxlang-miniserver-${version}.jar" ).toPath(), file( "build/evergreen/boxlang-miniserver-snapshot.jar" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+	        // Copy checksums
+			Files.copy( file( "build/distributions/boxlang-miniserver-${version}.zip.sha-256" ).toPath(), file( "build/evergreen/boxlang-miniserver-snapshot.zip.sha-256" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+			Files.copy( file( "build/distributions/boxlang-miniserver-${version}.zip.md5" ).toPath(), file( "build/evergreen/boxlang-miniserver-snapshot.zip.md5" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+			Files.copy( file( "build/distributions/boxlang-miniserver-${version}.jar.sha-256" ).toPath(), file( "build/evergreen/boxlang-miniserver-snapshot.jar.sha-256" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+			Files.copy( file( "build/distributions/boxlang-miniserver-${version}.jar.md5" ).toPath(), file( "build/evergreen/boxlang-miniserver-snapshot.jar.md5" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+	    } else {
+	        Files.copy( file( "build/distributions/boxlang-miniserver-${version}.zip" ).toPath(), file( "build/evergreen/boxlang-miniserver-latest.zip" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+	    }
 
 		println "+ Distribution file has been created"
 	}
 }
 build.finalizedBy( createDistributionFile )
+
+/**
+ * Generate checksums for the given file using the specified algorithm
+
+ * @param file The file to generate the checksum for
+ * @param algorithm The algorithm to use (e.g., "SHA-256", "MD5")
+ */
+def generateChecksum( File file, String algorithm ) {
+	def digest = java.security.MessageDigest.getInstance( algorithm )
+	file.eachByte( 4096 ) { bytes, size ->
+		digest.update( bytes, 0, size )
+	}
+	def checksum = digest.digest().collect { String.format( '%02x', it ) }.join()
+
+	def checksumFile = new File( file.parent, "${file.name}.${algorithm.toLowerCase()}" )
+	checksumFile.text = "${checksum}  ${file.name}\n"
+}
 
 /**
  * Publish the artifacts to the local maven repository

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2025-05-29
+
 ## [1.1.0] - 2025-05-12
 
 ### New Features
@@ -43,7 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] - 2025-04-30
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.2.0...HEAD
+
+[1.2.0]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.1.0...v1.2.0
 
 [1.1.0]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0...v1.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Mon May 12 20:29:03 UTC 2025
-boxlangVersion=1.2.0
+#Thu May 29 15:12:42 UTC 2025
+boxlangVersion=1.3.0
 jdkVersion=21
-version=1.2.0
+version=1.3.0
 group=ortus.boxlang

--- a/src/main/java/ortus/boxlang/web/MiniServer.java
+++ b/src/main/java/ortus/boxlang/web/MiniServer.java
@@ -46,16 +46,21 @@ import ortus.boxlang.web.handlers.WelcomeFileHandler;
  *
  * The following command line arguments are supported:
  *
- * --port <port> - The port to listen on. Default is 8080.
- * --webroot <path> - The path to the webroot. Default is {@code BOXLANG_HOME/www}
- * --debug - Enable debug mode or not. Default is false.
+ * --help, -h - Show help information and exit.
+ * --port, -p <port> - The port to listen on. Default is 8080.
+ * --webroot, -w <path> - The path to the webroot. Default is {@code BOXLANG_HOME/www}
+ * --debug, -d - Enable debug mode or not. Default is false.
  * --host <host> - The host to listen on. Default is {@code 0.0.0.0}.
+ * --configPath, -c <path> - Path to BoxLang configuration file.
+ * --serverHome, -s <path> - BoxLang server home directory.
+ * --rewrites, -r [file] - Enable URL rewrites with optional rewrite file name.
  *
  * Examples:
  *
  * <pre>
  * java -jar boxlang-miniserver.jar --webroot /path/to/webroot --debug
  * java -jar boxlang-miniserver.jar --port 80 --webroot /var/www
+ * java -jar boxlang-miniserver.jar --help
  * </pre>
  *
  * This will start the BoxLang MiniServer on port 8080, serving files from {@code /path/to/webroot}, and enable debug mode.
@@ -95,9 +100,12 @@ public class MiniServer {
 		Boolean				rewrites		= Boolean.parseBoolean( envVars.getOrDefault( "BOXLANG_REWRITES", "false" ) );
 		String				rewriteFileName	= envVars.getOrDefault( "BOXLANG_REWRITE_FILE", "index.bxm" );
 
-		// Grab --port and --webroot from args, if they exist
-		// If --debug is set, enable debug mode
+		// Grab command line arguments
 		for ( int i = 0; i < args.length; i++ ) {
+			if ( args[ i ].equalsIgnoreCase( "--help" ) || args[ i ].equalsIgnoreCase( "-h" ) ) {
+				printHelp();
+				System.exit( 0 );
+			}
 			if ( args[ i ].equalsIgnoreCase( "--port" ) || args[ i ].equalsIgnoreCase( "-p" ) ) {
 				port = Integer.parseInt( args[ ++i ] );
 			}
@@ -107,7 +115,7 @@ public class MiniServer {
 			if ( args[ i ].equalsIgnoreCase( "--debug" ) || args[ i ].equalsIgnoreCase( "-d" ) ) {
 				debug = true;
 			}
-			if ( args[ i ].equalsIgnoreCase( "--host" ) || args[ i ].equalsIgnoreCase( "-h" ) ) {
+			if ( args[ i ].equalsIgnoreCase( "--host" ) ) {
 				host = args[ ++i ];
 			}
 			if ( args[ i ].equalsIgnoreCase( "--configPath" ) || args[ i ].equalsIgnoreCase( "-c" ) ) {
@@ -255,6 +263,66 @@ public class MiniServer {
 	 */
 	public static WebsocketHandler getWebsocketHandler() {
 		return websocketHandler;
+	}
+
+	/**
+	 * Prints help information for the BoxLang MiniServer command-line interface.
+	 */
+	private static void printHelp() {
+		System.out.println( "🚀 BoxLang MiniServer - A fast, lightweight, pure Java web server for BoxLang applications" );
+		System.out.println();
+		System.out.println( "📋 USAGE:" );
+		System.out.println( "  boxlang-miniserver [OPTIONS]  # 🔧 Using OS binary" );
+		System.out.println( "  java -jar boxlang-miniserver.jar [OPTIONS] # 🐍 Using Java JAR" );
+		System.out.println();
+		System.out.println( "⚙️  OPTIONS:" );
+		System.out.println( "  -h, --help              ❓ Show this help message and exit" );
+		System.out.println( "  -p, --port <PORT>       🌐 Port to listen on (default: 8080)" );
+		System.out.println( "  -w, --webroot <PATH>    📁 Path to the webroot directory (default: current directory)" );
+		System.out.println( "  -d, --debug             🐛 Enable debug mode (true/false, default: false)" );
+		System.out.println( "      --host <HOST>       🏠 Host to bind to (default: 0.0.0.0)" );
+		System.out.println( "  -c, --configPath <PATH> ⚙️  Path to BoxLang configuration file (default: ~/.boxlang/config/boxlang.json)" );
+		System.out.println( "  -s, --serverHome <PATH> 🏡 BoxLang server home directory (default: ~/.boxlang)" );
+		System.out.println( "  -r, --rewrites [FILE]   🔀 Enable URL rewrites (default file: index.bxm)" );
+		System.out.println();
+		System.out.println( "🌍 ENVIRONMENT VARIABLES:" );
+		System.out.println( "  BOXLANG_CONFIG          📁 Path to BoxLang configuration file" );
+		System.out.println( "  BOXLANG_DEBUG           🐛 Enable debug mode (true/false)" );
+		System.out.println( "  BOXLANG_HOME            🏡 BoxLang server home directory" );
+		System.out.println( "  BOXLANG_HOST            🏠 Host to bind to" );
+		System.out.println( "  BOXLANG_PORT            🌐 Port to listen on" );
+		System.out.println( "  BOXLANG_REWRITE_FILE    📄 Rewrite target file" );
+		System.out.println( "  BOXLANG_REWRITES        🔀 Enable URL rewrites" );
+		System.out.println( "  BOXLANG_WEBROOT         📁 Path to the webroot directory" );
+		System.out.println( "  JAVA_OPTS               ⚙️  Java Virtual Machine options and system properties" );
+		System.out.println();
+		System.out.println( "💡 EXAMPLES:" );
+		System.out.println( "  # 🚀 Start server with default settings" );
+		System.out.println( "  boxlang-miniserver" );
+		System.out.println();
+		System.out.println( "  # 🌐 Start server on port 80 with custom webroot" );
+		System.out.println( "  boxlang-miniserver --port 80 --webroot /var/www" );
+		System.out.println();
+		System.out.println( "  # 🐛 Start server with debug mode and URL rewrites enabled" );
+		System.out.println( "  boxlang-miniserver --debug --rewrites" );
+		System.out.println();
+		System.out.println( "  # 🔀 Start server with custom rewrite file" );
+		System.out.println( "  boxlang-miniserver --rewrites app.bxm" );
+		System.out.println();
+		System.out.println( "  # 🚀 Start server with JVM memory settings" );
+		System.out.println( "  JAVA_OPTS=\"-Xms512m -Xmx2g\" boxlang-miniserver --port 8080" );
+		System.out.println();
+		System.out.println( "🏠 DEFAULT WELCOME FILES:" );
+		System.out.println( "  index.bxm, index.bxs, index.cfm, index.cfs, index.htm, index.html" );
+		System.out.println();
+		System.out.println( "🔌 WEBSOCKET SUPPORT:" );
+		System.out.println( "  WebSocket endpoint available at: ws://host:port/ws" );
+		System.out.println();
+		System.out.println( "📖 More Information:" );
+		System.out.println( "  📖 Documentation: https://boxlang.ortusbooks.com/" );
+		System.out.println( "  💬 Community: https://community.ortussolutions.com/c/boxlang/42" );
+		System.out.println( "  💾 GitHub: https://github.com/ortus-boxlang" );
+		System.out.println();
 	}
 
 }

--- a/src/main/java/ortus/boxlang/web/handlers/FrameworkRewritesBuilder.java
+++ b/src/main/java/ortus/boxlang/web/handlers/FrameworkRewritesBuilder.java
@@ -63,7 +63,7 @@ public class FrameworkRewritesBuilder implements HandlerBuilder {
 			@Override
 			public HttpHandler wrap( HttpHandler toWrap ) {
 				List<PredicatedHandler> ph = PredicatedHandlersParser.parse(
-				    "not regex('^/(ws)/.*')"
+				    "not regex('^/(ws|\\.well-known)/.*')"
 				        + "and not path(/favicon.ico)"
 				        + " and not is-file"
 				        + " and not is-directory -> rewrite( '/" + fileName + "%{DECODED_REQUEST_PATH}' )",


### PR DESCRIPTION
Release Notes
New Feature
[BL-1508](https://ortussolutions.atlassian.net/browse/BL-1508) Add `compressionLevel` to the zip component and utilities
[BL-1512](https://ortussolutions.atlassian.net/browse/BL-1512) Add checksums to all binary creations in the build process
[BL-1533](https://ortussolutions.atlassian.net/browse/BL-1533) xNone() for bif operations: array, list, query, struct
[BL-1542](https://ortussolutions.atlassian.net/browse/BL-1542) Added `pretty` argument to jsonSerialize() to allow for pretty serialization
Improvement
[BL-1471](https://ortussolutions.atlassian.net/browse/BL-1471) Add Examples to docs for BIFs and Components
[BL-1494](https://ortussolutions.atlassian.net/browse/BL-1494) Don't allow scopes to be "overridden" with scope hunting
[BL-1511](https://ortussolutions.atlassian.net/browse/BL-1511) Add Support for Compressed HTTP responses
[BL-1516](https://ortussolutions.atlassian.net/browse/BL-1516) arrayFind shouldn't throw on mismatched types
[BL-1519](https://ortussolutions.atlassian.net/browse/BL-1519) Small update to make sure only runtime dependencies are stored in the `lib` folder using our maven pom in the Boxlang home.
[BL-1521](https://ortussolutions.atlassian.net/browse/BL-1521) Add --help -h to Mini Server
[BL-1522](https://ortussolutions.atlassian.net/browse/BL-1522) Add --help -h to Feature Audit, CFTranspiler, Scheduler, BoxRunner and more
[BL-1526](https://ortussolutions.atlassian.net/browse/BL-1526) Bumps org.semver4j:semver4j from 5.7.0 to 5.7.1.
[BL-1528](https://ortussolutions.atlassian.net/browse/BL-1528) Add lazy expiration for caching
[BL-1534](https://ortussolutions.atlassian.net/browse/BL-1534) Query Concurrency Improvements : There are some inconsistencies and issues when dealing with adding data to queries in parallel threads
[BL-1536](https://ortussolutions.atlassian.net/browse/BL-1536) Bumps com.fasterxml.jackson.jr:jackson-jr-stree from 2.19.0 to 2.19.1.
[BL-1537](https://ortussolutions.atlassian.net/browse/BL-1537) Refactor @NonNull and @Nullable to use compile time checkers instead of runtime dependencies
[BL-1544](https://ortussolutions.atlassian.net/browse/BL-1544) Create a transpiler rule for cfquery params: `cfsqltype` to `sqltype`
Bugs
[BL-1216](https://ortussolutions.atlassian.net/browse/BL-1216) Image scaleToFit creating black images
[BL-1217](https://ortussolutions.atlassian.net/browse/BL-1217) Image resize not working as member func.
[BL-1472](https://ortussolutions.atlassian.net/browse/BL-1472) JDBC - Transaction defaults to app-default datasource, and ignores the datasource named in the first query
[BL-1501](https://ortussolutions.atlassian.net/browse/BL-1501) Compat: Math Operations Which Encounter Timestamps Should Cast as Fractional Days
[BL-1503](https://ortussolutions.atlassian.net/browse/BL-1503) Update parallel computations to use a tiered execution approach; xSome, xEvery, xMap, xFilter, xEach
[BL-1504](https://ortussolutions.atlassian.net/browse/BL-1504) looping groups breaks when it should continue
[BL-1507](https://ortussolutions.atlassian.net/browse/BL-1507) HTTP Errors When Uploading File
[BL-1513](https://ortussolutions.atlassian.net/browse/BL-1513) fix() behaviour is not equal to Lucee's behaviour
[BL-1523](https://ortussolutions.atlassian.net/browse/BL-1523) All multi-part form fields are being written to disk
[BL-1524](https://ortussolutions.atlassian.net/browse/BL-1524) CFCatch support when catch variable defined in bx-compat-cfml
[BL-1527](https://ortussolutions.atlassian.net/browse/BL-1527) DATETIME is not being aliased by query parameters in prepared statements
[BL-1529](https://ortussolutions.atlassian.net/browse/BL-1529) Several concurrency issues on cache entries created and last access timeouts
[BL-1530](https://ortussolutions.atlassian.net/browse/BL-1530) cache entry equals evaluating the hash codes incorrectly and causing collisions
[BL-1531](https://ortussolutions.atlassian.net/browse/BL-1531) Set base template for remote methods in super class
[BL-1532](https://ortussolutions.atlassian.net/browse/BL-1532) Better handle ../ in servlet paths
[BL-1541](https://ortussolutions.atlassian.net/browse/BL-1541) The `type` property in class metadata still references "component" instead of being "class"
[BL-1547](https://ortussolutions.atlassian.net/browse/BL-1547) duplicate function broken when using xml objects