### PR TITLE
v1.4.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,14 @@
 
 version: 2
 updates:
-  - package-ecosystem: "gradle" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # GitHub Actions - updates `uses:` statements in workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"                  # Where your `.github/workflows/` folder is
+    schedule:
+      interval: "weekly"
+
+  # Gradle - updates dependencies in build.gradle or build.gradle.kts
+  - package-ecosystem: "gradle"
+    directory: "/"                  # Adjust if build.gradle is in a subfolder
     schedule:
       interval: "weekly"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,7 +31,7 @@ jobs:
           distribution: "temurin"
           java-version: 21
 
-      - uses: Ortus-Solutions/commandbox-action@v1.0.2
+      - uses: Ortus-Solutions/commandbox-action@v1.0.3
         with:
           cmd: run-script format:check
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
           fi
 
       - name: Update changelog [unreleased] with latest version
-        uses: thomaseizinger/keep-a-changelog-new-release@2.0.0
+        uses: thomaseizinger/keep-a-changelog-new-release@3.1.0
         if: env.SNAPSHOT == 'false'
         with:
           changelogPath: ./changelog.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,7 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
 
       - name: Create Github Release
-        uses: taiki-e/create-gh-release-action@v1.8.0
+        uses: taiki-e/create-gh-release-action@v1.9.1
         continue-on-error: true
         if: env.SNAPSHOT == 'false'
         id: create_release

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -55,7 +55,7 @@ jobs:
       #     cmd: run-script format
 
       - name: Commit Format Changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v6
         with:
           commit_message: Apply cfformat changes
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ bin/**
 grapher/**
 /libs/
 src/test/resources/libs/
+/wwwServerHome
+/www

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,16 @@
 		},
 		{
 			"type": "java",
+			"name": "MiniServer-Help",
+			"request": "launch",
+			"mainClass": "ortus.boxlang.web.MiniServer",
+			"projectName": "boxlang-miniserver",
+			"args": [
+				"--help"
+			]
+		},
+		{
+			"type": "java",
 			"name": "MiniServer-TestWWW",
 			"request": "launch",
 			"mainClass": "ortus.boxlang.web.MiniServer",

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 	// https://github.com/harbby/gradle-serviceloader
     id "com.github.harbby.gradle.serviceloader" version "1.1.9"
 	// Shadow
-	id "com.gradleup.shadow" version "9.0.0-beta17"
+	id "com.gradleup.shadow" version "9.0.0-rc1"
     // Download task
     id "de.undercouch.download" version "5.6.0"
 	// Task visualizer

--- a/build.gradle
+++ b/build.gradle
@@ -166,6 +166,13 @@ task createDistributionFile( type: Zip ){
 			Files.copy( file( "build/distributions/boxlang-miniserver-${version}.jar.md5" ).toPath(), file( "build/evergreen/boxlang-miniserver-snapshot.jar.md5" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
 	    } else {
 	        Files.copy( file( "build/distributions/boxlang-miniserver-${version}.zip" ).toPath(), file( "build/evergreen/boxlang-miniserver-latest.zip" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+	        Files.copy( file( "build/distributions/boxlang-miniserver-${version}.jar" ).toPath(), file( "build/evergreen/boxlang-miniserver-latest.jar" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+	        // Copy checksums
+	        Files.copy( file( "build/distributions/boxlang-miniserver-${version}.zip.sha-256" ).toPath(), file( "build/evergreen/boxlang-miniserver-latest.zip.sha-256" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+			Files.copy( file( "build/distributions/boxlang-miniserver-${version}.zip.md5" ).toPath(), file( "build/evergreen/boxlang-miniserver-latest.zip.md5" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+			Files.copy( file( "build/distributions/boxlang-miniserver-${version}.jar.sha-256" ).toPath(), file( "build/evergreen/boxlang-miniserver-latest.jar.sha-256" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+			Files.copy( file( "build/distributions/boxlang-miniserver-${version}.jar.md5" ).toPath(), file( "build/evergreen/boxlang-miniserver-latest.jar.md5" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+			
 	    }
 
 		println "+ Distribution file has been created"

--- a/build.gradle
+++ b/build.gradle
@@ -144,20 +144,51 @@ task createDistributionFile( type: Zip ){
 	}
 	archiveFileName = "boxlang-miniserver-${version}.zip"
 	doLast {
-    Files.copy( file( "build/libs/boxlang-miniserver-${version}-javadoc.jar" ).toPath(), file( "build/distributions/boxlang-miniserver-${version}-javadoc.jar" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
 
-    file( "build/evergreen" ).mkdirs()
-    if( branch == 'development' ){
-        Files.copy( file( "build/distributions/boxlang-miniserver-${version}.zip" ).toPath(), file( "build/evergreen/boxlang-miniserver-snapshot.zip" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
-        Files.copy( file( "build/distributions/boxlang-miniserver-${version}.jar" ).toPath(), file( "build/evergreen/boxlang-miniserver-snapshot.jar" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
-    } else {
-        Files.copy( file( "build/distributions/boxlang-miniserver-${version}.zip" ).toPath(), file( "build/evergreen/boxlang-miniserver-latest.zip" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
-    }
+		// Generate checksums for all zip and jar files in distributions folder
+		file( "build/distributions" ).listFiles().each { file ->
+			if ( file.name.endsWith( '.zip' ) || file.name.endsWith( '.jar' ) ) {
+				generateChecksum( file, 'SHA-256' )
+				generateChecksum( file, 'MD5' )
+			}
+		}
+			
+	    Files.copy( file( "build/libs/boxlang-miniserver-${version}-javadoc.jar" ).toPath(), file( "build/distributions/boxlang-miniserver-${version}-javadoc.jar" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+
+	    file( "build/evergreen" ).mkdirs()
+	    if( branch == 'development' ){
+	        Files.copy( file( "build/distributions/boxlang-miniserver-${version}.zip" ).toPath(), file( "build/evergreen/boxlang-miniserver-snapshot.zip" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+	        Files.copy( file( "build/distributions/boxlang-miniserver-${version}.jar" ).toPath(), file( "build/evergreen/boxlang-miniserver-snapshot.jar" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+	        // Copy checksums
+			Files.copy( file( "build/distributions/boxlang-miniserver-${version}.zip.sha-256" ).toPath(), file( "build/evergreen/boxlang-miniserver-snapshot.zip.sha-256" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+			Files.copy( file( "build/distributions/boxlang-miniserver-${version}.zip.md5" ).toPath(), file( "build/evergreen/boxlang-miniserver-snapshot.zip.md5" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+			Files.copy( file( "build/distributions/boxlang-miniserver-${version}.jar.sha-256" ).toPath(), file( "build/evergreen/boxlang-miniserver-snapshot.jar.sha-256" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+			Files.copy( file( "build/distributions/boxlang-miniserver-${version}.jar.md5" ).toPath(), file( "build/evergreen/boxlang-miniserver-snapshot.jar.md5" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+	    } else {
+	        Files.copy( file( "build/distributions/boxlang-miniserver-${version}.zip" ).toPath(), file( "build/evergreen/boxlang-miniserver-latest.zip" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+	    }
 
 		println "+ Distribution file has been created"
 	}
 }
 build.finalizedBy( createDistributionFile )
+
+/**
+ * Generate checksums for the given file using the specified algorithm
+
+ * @param file The file to generate the checksum for
+ * @param algorithm The algorithm to use (e.g., "SHA-256", "MD5")
+ */
+def generateChecksum( File file, String algorithm ) {
+	def digest = java.security.MessageDigest.getInstance( algorithm )
+	file.eachByte( 4096 ) { bytes, size ->
+		digest.update( bytes, 0, size )
+	}
+	def checksum = digest.digest().collect { String.format( '%02x', it ) }.join()
+
+	def checksumFile = new File( file.parent, "${file.name}.${algorithm.toLowerCase()}" )
+	checksumFile.text = "${checksum}  ${file.name}\n"
+}
 
 /**
  * Publish the artifacts to the local maven repository

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 	// This produces the distributions and scripts for any OS
 	id "application"
     // For source code formatting
-    id "com.diffplug.spotless" version "7.1.0"
+    id "com.diffplug.spotless" version "7.2.1"
 	// https://github.com/harbby/gradle-serviceloader
     id "com.github.harbby.gradle.serviceloader" version "1.1.9"
 	// Shadow

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 	// This produces the distributions and scripts for any OS
 	id "application"
     // For source code formatting
-    id "com.diffplug.spotless" version "7.0.3"
+    id "com.diffplug.spotless" version "7.1.0"
 	// https://github.com/harbby/gradle-serviceloader
     id "com.github.harbby.gradle.serviceloader" version "1.1.9"
 	// Shadow

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2025-06-23
+
 ## [1.2.0] - 2025-05-29
 
 ## [1.1.0] - 2025-05-12
@@ -45,7 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] - 2025-04-30
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.3.0...HEAD
+
+[1.3.0]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.2.0...v1.3.0
 
 [1.2.0]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.1.0...v1.2.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2025-05-29
+
 ## [1.1.0] - 2025-05-12
 
 ### New Features
@@ -43,7 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] - 2025-04-30
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.2.0...HEAD
+
+[1.2.0]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.1.0...v1.2.0
 
 [1.1.0]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.0.0...v1.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Thu May 29 15:12:42 UTC 2025
-boxlangVersion=1.3.0
+#Mon Jun 23 16:11:03 UTC 2025
+boxlangVersion=1.4.0
 jdkVersion=21
-version=1.3.0
+version=1.4.0
 group=ortus.boxlang

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Mon May 12 20:29:03 UTC 2025
-boxlangVersion=1.2.0
+#Thu May 29 15:12:42 UTC 2025
+boxlangVersion=1.3.0
 jdkVersion=21
-version=1.2.0
+version=1.3.0
 group=ortus.boxlang

--- a/src/main/java/ortus/boxlang/web/MiniServer.java
+++ b/src/main/java/ortus/boxlang/web/MiniServer.java
@@ -46,16 +46,21 @@ import ortus.boxlang.web.handlers.WelcomeFileHandler;
  *
  * The following command line arguments are supported:
  *
- * --port <port> - The port to listen on. Default is 8080.
- * --webroot <path> - The path to the webroot. Default is {@code BOXLANG_HOME/www}
- * --debug - Enable debug mode or not. Default is false.
+ * --help, -h - Show help information and exit.
+ * --port, -p <port> - The port to listen on. Default is 8080.
+ * --webroot, -w <path> - The path to the webroot. Default is {@code BOXLANG_HOME/www}
+ * --debug, -d - Enable debug mode or not. Default is false.
  * --host <host> - The host to listen on. Default is {@code 0.0.0.0}.
+ * --configPath, -c <path> - Path to BoxLang configuration file.
+ * --serverHome, -s <path> - BoxLang server home directory.
+ * --rewrites, -r [file] - Enable URL rewrites with optional rewrite file name.
  *
  * Examples:
  *
  * <pre>
  * java -jar boxlang-miniserver.jar --webroot /path/to/webroot --debug
  * java -jar boxlang-miniserver.jar --port 80 --webroot /var/www
+ * java -jar boxlang-miniserver.jar --help
  * </pre>
  *
  * This will start the BoxLang MiniServer on port 8080, serving files from {@code /path/to/webroot}, and enable debug mode.
@@ -95,9 +100,12 @@ public class MiniServer {
 		Boolean				rewrites		= Boolean.parseBoolean( envVars.getOrDefault( "BOXLANG_REWRITES", "false" ) );
 		String				rewriteFileName	= envVars.getOrDefault( "BOXLANG_REWRITE_FILE", "index.bxm" );
 
-		// Grab --port and --webroot from args, if they exist
-		// If --debug is set, enable debug mode
+		// Grab command line arguments
 		for ( int i = 0; i < args.length; i++ ) {
+			if ( args[ i ].equalsIgnoreCase( "--help" ) || args[ i ].equalsIgnoreCase( "-h" ) ) {
+				printHelp();
+				System.exit( 0 );
+			}
 			if ( args[ i ].equalsIgnoreCase( "--port" ) || args[ i ].equalsIgnoreCase( "-p" ) ) {
 				port = Integer.parseInt( args[ ++i ] );
 			}
@@ -107,7 +115,7 @@ public class MiniServer {
 			if ( args[ i ].equalsIgnoreCase( "--debug" ) || args[ i ].equalsIgnoreCase( "-d" ) ) {
 				debug = true;
 			}
-			if ( args[ i ].equalsIgnoreCase( "--host" ) || args[ i ].equalsIgnoreCase( "-h" ) ) {
+			if ( args[ i ].equalsIgnoreCase( "--host" ) ) {
 				host = args[ ++i ];
 			}
 			if ( args[ i ].equalsIgnoreCase( "--configPath" ) || args[ i ].equalsIgnoreCase( "-c" ) ) {
@@ -255,6 +263,66 @@ public class MiniServer {
 	 */
 	public static WebsocketHandler getWebsocketHandler() {
 		return websocketHandler;
+	}
+
+	/**
+	 * Prints help information for the BoxLang MiniServer command-line interface.
+	 */
+	private static void printHelp() {
+		System.out.println( "🚀 BoxLang MiniServer - A fast, lightweight, pure Java web server for BoxLang applications" );
+		System.out.println();
+		System.out.println( "📋 USAGE:" );
+		System.out.println( "  boxlang-miniserver [OPTIONS]  # 🔧 Using OS binary" );
+		System.out.println( "  java -jar boxlang-miniserver.jar [OPTIONS] # 🐍 Using Java JAR" );
+		System.out.println();
+		System.out.println( "⚙️  OPTIONS:" );
+		System.out.println( "  -h, --help              ❓ Show this help message and exit" );
+		System.out.println( "  -p, --port <PORT>       🌐 Port to listen on (default: 8080)" );
+		System.out.println( "  -w, --webroot <PATH>    📁 Path to the webroot directory (default: current directory)" );
+		System.out.println( "  -d, --debug             🐛 Enable debug mode (true/false, default: false)" );
+		System.out.println( "      --host <HOST>       🏠 Host to bind to (default: 0.0.0.0)" );
+		System.out.println( "  -c, --configPath <PATH> ⚙️  Path to BoxLang configuration file (default: ~/.boxlang/config/boxlang.json)" );
+		System.out.println( "  -s, --serverHome <PATH> 🏡 BoxLang server home directory (default: ~/.boxlang)" );
+		System.out.println( "  -r, --rewrites [FILE]   🔀 Enable URL rewrites (default file: index.bxm)" );
+		System.out.println();
+		System.out.println( "🌍 ENVIRONMENT VARIABLES:" );
+		System.out.println( "  BOXLANG_CONFIG          📁 Path to BoxLang configuration file" );
+		System.out.println( "  BOXLANG_DEBUG           🐛 Enable debug mode (true/false)" );
+		System.out.println( "  BOXLANG_HOME            🏡 BoxLang server home directory" );
+		System.out.println( "  BOXLANG_HOST            🏠 Host to bind to" );
+		System.out.println( "  BOXLANG_PORT            🌐 Port to listen on" );
+		System.out.println( "  BOXLANG_REWRITE_FILE    📄 Rewrite target file" );
+		System.out.println( "  BOXLANG_REWRITES        🔀 Enable URL rewrites" );
+		System.out.println( "  BOXLANG_WEBROOT         📁 Path to the webroot directory" );
+		System.out.println( "  JAVA_OPTS               ⚙️  Java Virtual Machine options and system properties" );
+		System.out.println();
+		System.out.println( "💡 EXAMPLES:" );
+		System.out.println( "  # 🚀 Start server with default settings" );
+		System.out.println( "  boxlang-miniserver" );
+		System.out.println();
+		System.out.println( "  # 🌐 Start server on port 80 with custom webroot" );
+		System.out.println( "  boxlang-miniserver --port 80 --webroot /var/www" );
+		System.out.println();
+		System.out.println( "  # 🐛 Start server with debug mode and URL rewrites enabled" );
+		System.out.println( "  boxlang-miniserver --debug --rewrites" );
+		System.out.println();
+		System.out.println( "  # 🔀 Start server with custom rewrite file" );
+		System.out.println( "  boxlang-miniserver --rewrites app.bxm" );
+		System.out.println();
+		System.out.println( "  # 🚀 Start server with JVM memory settings" );
+		System.out.println( "  JAVA_OPTS=\"-Xms512m -Xmx2g\" boxlang-miniserver --port 8080" );
+		System.out.println();
+		System.out.println( "🏠 DEFAULT WELCOME FILES:" );
+		System.out.println( "  index.bxm, index.bxs, index.cfm, index.cfs, index.htm, index.html" );
+		System.out.println();
+		System.out.println( "🔌 WEBSOCKET SUPPORT:" );
+		System.out.println( "  WebSocket endpoint available at: ws://host:port/ws" );
+		System.out.println();
+		System.out.println( "📖 More Information:" );
+		System.out.println( "  📖 Documentation: https://boxlang.ortusbooks.com/" );
+		System.out.println( "  💬 Community: https://community.ortussolutions.com/c/boxlang/42" );
+		System.out.println( "  💾 GitHub: https://github.com/ortus-boxlang" );
+		System.out.println();
 	}
 
 }

--- a/src/main/java/ortus/boxlang/web/handlers/FrameworkRewritesBuilder.java
+++ b/src/main/java/ortus/boxlang/web/handlers/FrameworkRewritesBuilder.java
@@ -63,7 +63,7 @@ public class FrameworkRewritesBuilder implements HandlerBuilder {
 			@Override
 			public HttpHandler wrap( HttpHandler toWrap ) {
 				List<PredicatedHandler> ph = PredicatedHandlersParser.parse(
-				    "not regex('^/(ws)/.*')"
+				    "not regex('^/(ws|\\.well-known)/.*')"
 				        + "and not path(/favicon.ico)"
 				        + " and not is-file"
 				        + " and not is-directory -> rewrite( '/" + fileName + "%{DECODED_REQUEST_PATH}' )",


### PR DESCRIPTION
Release Notes
Improvement
[BL-1517](https://ortussolutions.atlassian.net/browse/BL-1517) Update the feature audit tool with the correct modules
[BL-1518](https://ortussolutions.atlassian.net/browse/BL-1518) Remove all JavaParser dependencies externally unless you check if it exists
[BL-1565](https://ortussolutions.atlassian.net/browse/BL-1565) improve error message on expression interpreter
[BL-1566](https://ortussolutions.atlassian.net/browse/BL-1566) Handle attempt.orThrow() better
[BL-1571](https://ortussolutions.atlassian.net/browse/BL-1571) Support some more natural date parsing masks which aren't case sensitive
[BL-1577](https://ortussolutions.atlassian.net/browse/BL-1577) lookup of custom componets and classes refactoring for performance
[BL-1579](https://ortussolutions.atlassian.net/browse/BL-1579) String performance and optimizations improvements for toScript() bif
[BL-1581](https://ortussolutions.atlassian.net/browse/BL-1581) Bump org.semver4j:semver4j from 5.8.0 to 6.0.0
[BL-1601](https://ortussolutions.atlassian.net/browse/BL-1601) avoid calling unputStream.available() due to FusionReactor bug
[BL-1604](https://ortussolutions.atlassian.net/browse/BL-1604) make module classes visible to context classloader
[BL-1618](https://ortussolutions.atlassian.net/browse/BL-1618) Update jackson-jr to latest patch
[BL-1625](https://ortussolutions.atlassian.net/browse/BL-1625) skip type coercion for === operator
[BL-1636](https://ortussolutions.atlassian.net/browse/BL-1636) default non-existent request bodies to an empty string
[BL-1642](https://ortussolutions.atlassian.net/browse/BL-1642) Ignore extra padding on base64 encoded strings
[BL-1647](https://ortussolutions.atlassian.net/browse/BL-1647) remove JSON serialization limit
[BL-1648](https://ortussolutions.atlassian.net/browse/BL-1648) Improve JSON serialization of throwable
[BL-1651](https://ortussolutions.atlassian.net/browse/BL-1651) org.apache.commons:commons-fileupload2-jakarta-servlet5
[BL-1653](https://ortussolutions.atlassian.net/browse/BL-1653) Re-organize and add validation to loaded miniserver config options
[BL-1656](https://ortussolutions.atlassian.net/browse/BL-1656) Bump org.apache.commons:commons-text from 1.13.1 to 1.14.0 (#288)
[BL-1657](https://ortussolutions.atlassian.net/browse/BL-1657) Bump commons-io:commons-io from 2.19.0 to 2.20.0
[BL-1659](https://ortussolutions.atlassian.net/browse/BL-1659) Re-instate parsing errors for unclosed brackets
Bug
[BL-1214](https://ortussolutions.atlassian.net/browse/BL-1214) Documentation of Image module
[BL-1367](https://ortussolutions.atlassian.net/browse/BL-1367) BX Compiler Issues
[BL-1415](https://ortussolutions.atlassian.net/browse/BL-1415) Cast error on BoxFuture.all()
[BL-1496](https://ortussolutions.atlassian.net/browse/BL-1496) Can't cast a Java Array to a modifiable Array.
[BL-1539](https://ortussolutions.atlassian.net/browse/BL-1539) DateFormat vs TimeFormat vs DateTimeFormat BIF Separations
[BL-1548](https://ortussolutions.atlassian.net/browse/BL-1548) Private static struct function not found
[BL-1555](https://ortussolutions.atlassian.net/browse/BL-1555) round does not accept second argument for number of places, despite being documented
[BL-1562](https://ortussolutions.atlassian.net/browse/BL-1562) Issue with clone when using zonedatetimes
[BL-1564](https://ortussolutions.atlassian.net/browse/BL-1564) dump template for Java class not handling static field
[BL-1567](https://ortussolutions.atlassian.net/browse/BL-1567) java boxpiler not always compiling array literal
[BL-1568](https://ortussolutions.atlassian.net/browse/BL-1568) JDBC - Unable to execute query in nested transaction unless outer transaction has a query that executes first
[BL-1569](https://ortussolutions.atlassian.net/browse/BL-1569) JDBC - Failed to set savepoint... is too long
[BL-1570](https://ortussolutions.atlassian.net/browse/BL-1570) date mask when parsing string dates
[BL-1573](https://ortussolutions.atlassian.net/browse/BL-1573) Fix for this scope access from function in custom tag
[BL-1575](https://ortussolutions.atlassian.net/browse/BL-1575) stack overflow in session shutdown cache interceptor
[BL-1578](https://ortussolutions.atlassian.net/browse/BL-1578) ToscriptTest not accounting for the timezone of the tests
[BL-1580](https://ortussolutions.atlassian.net/browse/BL-1580) ParseDateTimeTest using non timezone tests and would be unpredictable on certain conditions
[BL-1582](https://ortussolutions.atlassian.net/browse/BL-1582) bx:component is missing attributecollection argument
[BL-1584](https://ortussolutions.atlassian.net/browse/BL-1584) DateTimeCaster does not handle request timezones Zones correctly
[BL-1585](https://ortussolutions.atlassian.net/browse/BL-1585) CFML Compat with partial years
[BL-1587](https://ortussolutions.atlassian.net/browse/BL-1587) Different return type when calling `getTime()` on `java.util.GregorianCalendar`
[BL-1588](https://ortussolutions.atlassian.net/browse/BL-1588) StructSort numeric not sorting on values
[BL-1589](https://ortussolutions.atlassian.net/browse/BL-1589) Regular expression back reference is being ignored
[BL-1592](https://ortussolutions.atlassian.net/browse/BL-1592) ASM not compiling self-closing custom components the same as Java boxpiler
[BL-1593](https://ortussolutions.atlassian.net/browse/BL-1593) outer loop loses query context after inner loop
[BL-1594](https://ortussolutions.atlassian.net/browse/BL-1594) Issue with JSON serialization of dates in a BL class
[BL-1596](https://ortussolutions.atlassian.net/browse/BL-1596) session cookie - samesite handling
[BL-1597](https://ortussolutions.atlassian.net/browse/BL-1597) ArrayResize does not accept long
[BL-1598](https://ortussolutions.atlassian.net/browse/BL-1598) WriteDump Error on Null Array Values
[BL-1606](https://ortussolutions.atlassian.net/browse/BL-1606) Compat: DeSerializeJSON strictMapping ignored
[BL-1607](https://ortussolutions.atlassian.net/browse/BL-1607) SessionRotate and SessionInvalidate null out JSessionId
[BL-1610](https://ortussolutions.atlassian.net/browse/BL-1610) ACF parseDateTime compat
[BL-1611](https://ortussolutions.atlassian.net/browse/BL-1611) Casting ortus.boxlang.runtime.types.DateTime to java.util.Date
[BL-1612](https://ortussolutions.atlassian.net/browse/BL-1612) outer for loop loses query context with inner for loop
[BL-1613](https://ortussolutions.atlassian.net/browse/BL-1613) queryDeleteColumn deletes the column but not the data from the query object
[BL-1615](https://ortussolutions.atlassian.net/browse/BL-1615) fileRead should handle relative files
[BL-1616](https://ortussolutions.atlassian.net/browse/BL-1616) now isn't being cast to java.util.Date
[BL-1620](https://ortussolutions.atlassian.net/browse/BL-1620) Grouped looping is not showing expected output when not inner grouping
[BL-1621](https://ortussolutions.atlassian.net/browse/BL-1621) JDBC - Query caching into bx-redis throws 'failed to serialize object'
[BL-1622](https://ortussolutions.atlassian.net/browse/BL-1622) Httpparam formfield is adding a break line on values when multipart is true
[BL-1623](https://ortussolutions.atlassian.net/browse/BL-1623) FileGetMimeType with strict should be based on file content
[BL-1624](https://ortussolutions.atlassian.net/browse/BL-1624) Deserialized Query Columns are Invalid because they no longer contain query reference
[BL-1626](https://ortussolutions.atlassian.net/browse/BL-1626) DateTime does not properly deserialize because formatter is transient
[BL-1627](https://ortussolutions.atlassian.net/browse/BL-1627) val() with negative value returns 0
[BL-1628](https://ortussolutions.atlassian.net/browse/BL-1628) regex replacement backreferences greater than 9 don't wor
[BL-1629](https://ortussolutions.atlassian.net/browse/BL-1629) regex upper/lower case escapes should apply to all replacement text
[BL-1630](https://ortussolutions.atlassian.net/browse/BL-1630) JDBC race conditions present in threaded (or Future-ed) query execution
[BL-1632](https://ortussolutions.atlassian.net/browse/BL-1632) Zip includes target directory as first level parent.
[BL-1633](https://ortussolutions.atlassian.net/browse/BL-1633) queryObject.columnnames not supported
[BL-1634](https://ortussolutions.atlassian.net/browse/BL-1634) cfcontent is causing files to be corrupted
[BL-1635](https://ortussolutions.atlassian.net/browse/BL-1635) java double[] not handled by writeoutput / SerializeJSON
[BL-1639](https://ortussolutions.atlassian.net/browse/BL-1639) `max` and `min` member functions missing
[BL-1641](https://ortussolutions.atlassian.net/browse/BL-1641) list BIFs have inconsistent support for multiCharacterDelimiter
[BL-1652](https://ortussolutions.atlassian.net/browse/BL-1652) PlacehbolderReplacer was not using the String Caster when dealing with map bindings.
[BL-1658](https://ortussolutions.atlassian.net/browse/BL-1658) Servlet: Missing UTF-8 encoding for form fields with multipart/form-data
New Feature
[BL-842](https://ortussolutions.atlassian.net/browse/BL-842) .env support for the BoxLang miniserver
[BL-1464](https://ortussolutions.atlassian.net/browse/BL-1464) implement nested grouped output/looping
BL-1515 Add zipparam support for ZIP functionality
BL-1525 BoxLang mappings need to have an extra definition: external which defaults to false
BL-1595 runAsync is the alias, the main method is asyncRun() so we can use the `asyncX` namespace
BL-1609 asyncAll, asyncAllApply, asyncAny bifs and constructs for parallel programming
BL-1654 Add simple health checks for miniserver, especially for container based loading
BL-1655 Basic hidden file protection in MiniServer
Task
BL-1576 Refactor customTagsDirectory to customComponentsDirectory and add shim to support it
[BL-1637](https://ortussolutions.atlassian.net/browse/BL-1637) Rename thisTag scope to thisComponent scope for consistency and transpile the old scope

[BL-1517]: https://ortussolutions.atlassian.net/browse/BL-1517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1518]: https://ortussolutions.atlassian.net/browse/BL-1518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1565]: https://ortussolutions.atlassian.net/browse/BL-1565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1566]: https://ortussolutions.atlassian.net/browse/BL-1566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1571]: https://ortussolutions.atlassian.net/browse/BL-1571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1577]: https://ortussolutions.atlassian.net/browse/BL-1577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1579]: https://ortussolutions.atlassian.net/browse/BL-1579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1581]: https://ortussolutions.atlassian.net/browse/BL-1581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1601]: https://ortussolutions.atlassian.net/browse/BL-1601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ