### PR TITLE
version bump

### DIFF
--- a/MINISERVER_JSON.md
+++ b/MINISERVER_JSON.md
@@ -44,6 +44,7 @@ All the following options are supported in the JSON configuration file:
 | `rewriteFileName` | string | "index.bxm" | Rewrite target file |
 | `healthCheck` | boolean | false | Enable health check endpoints |
 | `healthCheckSecure` | boolean | false | Restrict detailed health info to localhost only |
+| `useProxyHeaders` | boolean | false | Use `X-Forwarded-*` headers supplied by a trusted reverse proxy |
 | `envFile` | string | null | Path to custom environment file (relative or absolute) |
 | `passPredicate` | string | *(see below)* | Undertow predicate expression that determines which requests are routed to BoxLang |
 | `warmupUrl` | string | null | Single URL to call after server starts (for application warmup) |
@@ -88,6 +89,7 @@ All the following options are supported in the JSON configuration file:
   "rewriteFileName": "index.bxm",
   "healthCheck": true,
   "healthCheckSecure": true,
+  "useProxyHeaders": true,
   "serverHome": "/opt/boxlang",
   "envFile": "/etc/boxlang/.env.production"
 }
@@ -107,6 +109,7 @@ All the following options are supported in the JSON configuration file:
   "rewriteFileName": "index.bxm",
   "healthCheck": true,
   "healthCheckSecure": false,
+  "useProxyHeaders": false,
   "envFile": ".env.production",
   "passPredicate": "regex( '^(/.+?\\.cfml|/.+?\\.cf[cms]|.+?\\.bx[ms]{0,1})(/.*)?$' )",
   "warmupUrl": "/index.bxm"
@@ -269,6 +272,18 @@ Keys must match constant names in [`org.xnio.Options`](https://github.com/xnio/x
 - Unknown option names emit a warning at startup and are skipped — the server still starts
 - JSON number values are coerced to the correct type (`int`, `long`, or `boolean`) as declared by Undertow/XNIO
 - Worker and socket options both reference `org.xnio.Options`; the distinction is only which builder method is called
+
+## Proxy Headers
+
+Set `useProxyHeaders` to `true` when the MiniServer is behind a **trusted** reverse proxy that supplies `X-Forwarded-*` headers. This enables Undertow's `ProxyPeerAddressHandler`, allowing the application to see the forwarded client address, host, port, and protocol.
+
+Only enable this setting when direct access to the MiniServer is restricted to trusted proxies. Otherwise, clients can send spoofed forwarded headers.
+
+| Method | Example |
+|--------|---------|
+| `miniserver.json` | `"useProxyHeaders": true` |
+| CLI argument | `--use-proxy-headers` |
+| Environment variable | `BOXLANG_USE_PROXY_HEADERS=true` |
 
 ## Configuration Priority
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.0] - 2026-07-08
+
 ## [1.14.0] - 2026-06-03
 
 ## [1.13.0] - 2026-05-01
@@ -73,7 +75,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * * *
 
-[unreleased]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.14.0...HEAD
+[unreleased]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.15.0...HEAD
+[1.15.0]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.14.0...v1.15.0
 [1.14.0]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.13.0...v1.14.0
 [1.13.0]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/ortus-boxlang/boxlang-miniserver/compare/v1.11.0...v1.12.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Wed Jun 03 09:35:54 UTC 2026
-boxlangVersion=1.15.0
+#Wed Jul 08 21:08:46 UTC 2026
+boxlangVersion=1.16.0
 jdkVersion=21
-version=1.15.0
+version=1.16.0
 group=ortus.boxlang

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,7 @@ Example `miniserver.json`:
   "rewriteFileName": "index.bxm",
   "healthCheck": true,
   "healthCheckSecure": false,
+  "useProxyHeaders": false,
   "envFile": null,
   "passPredicate": null,
   "undertowOptions": {
@@ -64,6 +65,7 @@ Example `miniserver.json`:
 - `rewriteFileName` (string) - Rewrite target file (default: "index.bxm")
 - `healthCheck` (boolean) - Enable health check endpoints
 - `healthCheckSecure` (boolean) - Restrict detailed health info to localhost only
+- `useProxyHeaders` (boolean) - Use `X-Forwarded-*` headers from a trusted reverse proxy
 - `envFile` (string) - Path to custom environment file
 - `passPredicate` (string) - Undertow predicate expression for BoxLang request routing (default: matches `.bxm`, `.bxs`, `.bx`, `.cfm`, `.cfc`, `.cfs`, `.cfml` extensions)
 - `warmupUrl` (string) - Single URL to call after server starts

--- a/src/main/java/ortus/boxlang/web/MiniServer.java
+++ b/src/main/java/ortus/boxlang/web/MiniServer.java
@@ -44,6 +44,7 @@ import io.undertow.predicate.Predicates;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.handlers.MetricsHandler;
+import io.undertow.server.handlers.ProxyPeerAddressHandler;
 import io.undertow.server.handlers.encoding.ContentEncodingRepository;
 import io.undertow.server.handlers.encoding.EncodingHandler;
 import io.undertow.server.handlers.encoding.GzipEncodingProvider;
@@ -269,6 +270,7 @@ public class MiniServer {
 		System.out.println( "  - Server Home: " + config.serverHome );
 		System.out.println( "  - Health Check: " + config.healthCheck );
 		System.out.println( "  - Health Check Secure: " + config.healthCheckSecure );
+		System.out.println( "  - Use Proxy Headers: " + config.useProxyHeaders );
 		System.out.println( "+ Starting BoxLang Runtime..." );
 
 		// Startup the runtime
@@ -546,7 +548,14 @@ public class MiniServer {
 		}
 
 		// Wrap with exchange setter for WebSocket integration
-		return createExchangeSetterHandler( httpHandler );
+		httpHandler = createExchangeSetterHandler( httpHandler );
+
+		if ( config.useProxyHeaders ) {
+			System.out.println( "+ Proxy peer address handling enabled" );
+			httpHandler = new ProxyPeerAddressHandler( httpHandler );
+		}
+
+		return httpHandler;
 	}
 
 	/**
@@ -756,6 +765,7 @@ public class MiniServer {
 		System.out.println( "    \"rewriteFileName\": \"index.bxm\"," );
 		System.out.println( "    \"healthCheck\": true," );
 		System.out.println( "    \"healthCheckSecure\": false," );
+		System.out.println( "    \"useProxyHeaders\": false," );
 		System.out.println( "    \"envFile\": \".env.local\"," );
 		System.out.println( "    \"passPredicate\": \"regex( '^(/.+?\\\\.cfml|/.+?\\\\.cf[cms]|.+?\\\\.bx[ms]{0,1})(/.*)?$' )\"," );
 		System.out.println( "    \"warmupUrl\": \"/index.bxm\"," );
@@ -774,6 +784,7 @@ public class MiniServer {
 		System.out.println( "  -r, --rewrites [FILE]   🔀 Enable URL rewrites (default file: index.bxm)" );
 		System.out.println( "      --health-check      ❤️  Enable health check endpoints (/health, /health/ready, /health/live)" );
 		System.out.println( "      --health-check-secure 🔒 Restrict detailed health info to localhost only" );
+		System.out.println( "      --use-proxy-headers 🛡️  Use X-Forwarded-* headers supplied by a trusted proxy" );
 		System.out.println( "      --warmup-url <URL>  🔥 URL to call after server starts (can be repeated for multiple URLs)" );
 		System.out.println( "      --pass-predicate <EXPR> 🎯 Undertow predicate for BoxLang request routing (overrides default file-extension matching)" );
 		System.out.println();
@@ -788,6 +799,7 @@ public class MiniServer {
 		System.out.println( "  BOXLANG_WEBROOT         📁 Path to the webroot directory" );
 		System.out.println( "  BOXLANG_HEALTH_CHECK    ❤️  Enable health check endpoints (true/false)" );
 		System.out.println( "  BOXLANG_HEALTH_CHECK_SECURE 🔒 Restrict detailed health info to localhost only (true/false)" );
+		System.out.println( "  BOXLANG_USE_PROXY_HEADERS 🛡️  Use X-Forwarded-* headers from a trusted proxy (true/false)" );
 		System.out.println( "  BOXLANG_PASS_PREDICATE  🎯 Undertow predicate for BoxLang request routing" );
 		System.out.println( "  JAVA_OPTS               ⚙️  Java Virtual Machine options and system properties" );
 		System.out.println();

--- a/src/main/java/ortus/boxlang/web/config/MiniServerConfig.java
+++ b/src/main/java/ortus/boxlang/web/config/MiniServerConfig.java
@@ -170,6 +170,9 @@ public class MiniServerConfig {
 	/** Restrict detailed health info to localhost only. Default: false */
 	public Boolean				healthCheckSecure	= false;
 
+	/** Use proxy-provided client address headers. Default: false */
+	public Boolean				useProxyHeaders		= false;
+
 	/** Path to a .env file to load. Null means auto-detect from webroot. */
 	public String				envFile				= null;
 
@@ -246,6 +249,7 @@ public class MiniServerConfig {
 		config.rewriteFileName		= envVars.getOrDefault( "BOXLANG_REWRITE_FILE", DEFAULT_REWRITE_FILE );
 		config.healthCheck			= Boolean.parseBoolean( envVars.getOrDefault( "BOXLANG_HEALTH_CHECK", "false" ) );
 		config.healthCheckSecure	= Boolean.parseBoolean( envVars.getOrDefault( "BOXLANG_HEALTH_CHECK_SECURE", "false" ) );
+		config.useProxyHeaders		= Boolean.parseBoolean( envVars.getOrDefault( "BOXLANG_USE_PROXY_HEADERS", "false" ) );
 		config.passPredicate		= envVars.getOrDefault( "BOXLANG_PASS_PREDICATE", DEFAULT_PASS_PREDICATE );
 
 		// 2. JSON configuration file
@@ -324,6 +328,8 @@ public class MiniServerConfig {
 				config.healthCheck = true;
 			} else if ( arg.equalsIgnoreCase( "--health-check-secure" ) ) {
 				config.healthCheckSecure = true;
+			} else if ( arg.equalsIgnoreCase( "--use-proxy-headers" ) ) {
+				config.useProxyHeaders = true;
 			} else if ( arg.equalsIgnoreCase( "--pass-predicate" ) ) {
 				if ( i + 1 >= args.length ) {
 					throw new IllegalArgumentException( "Pass predicate argument requires a value" );
@@ -413,6 +419,9 @@ public class MiniServerConfig {
 			}
 			if ( jsonConfig.containsKey( "healthCheckSecure" ) && jsonConfig.get( "healthCheckSecure" ) != null ) {
 				healthCheckSecure = BooleanCaster.cast( jsonConfig.get( "healthCheckSecure" ) );
+			}
+			if ( jsonConfig.containsKey( "useProxyHeaders" ) && jsonConfig.get( "useProxyHeaders" ) != null ) {
+				useProxyHeaders = BooleanCaster.cast( jsonConfig.get( "useProxyHeaders" ) );
 			}
 			if ( jsonConfig.containsKey( "envFile" ) && jsonConfig.get( "envFile" ) != null ) {
 				envFile = StringCaster.cast( jsonConfig.get( "envFile" ) );

--- a/src/main/java/ortus/boxlang/web/exchange/BoxHTTPUndertowExchange.java
+++ b/src/main/java/ortus/boxlang/web/exchange/BoxHTTPUndertowExchange.java
@@ -49,6 +49,7 @@ import io.undertow.server.handlers.Cookie;
 import io.undertow.server.handlers.CookieImpl;
 import io.undertow.server.handlers.form.FormData;
 import io.undertow.server.handlers.form.FormDataParser;
+import io.undertow.server.handlers.form.FormEncodedDataDefinition;
 import io.undertow.server.handlers.form.FormParserFactory;
 import io.undertow.server.handlers.form.MultiPartParserDefinition;
 import io.undertow.util.HeaderMap;
@@ -369,7 +370,12 @@ public class BoxHTTPUndertowExchange implements IBoxHTTPExchange {
 		// Instead of manually creating them, I'll just look for the one we care about, and tweak it.
 		// The multi-part parser will only actually be used if the request content type is multipart/form-data
 		for ( var parser : formParserBuilder.getParsers() ) {
+			if ( parser instanceof FormEncodedDataDefinition fed ) {
+				fed.setDefaultEncoding( "UTF-8" );
+			}
+
 			if ( parser instanceof MultiPartParserDefinition mppd ) {
+				mppd.setDefaultEncoding( "UTF-8" );
 				// Store all files on disk
 				mppd.setFileSizeThreshold( 0 );
 				// Never store input fields on disk

--- a/src/main/java/ortus/boxlang/web/handlers/FrameworkRewritesBuilder.java
+++ b/src/main/java/ortus/boxlang/web/handlers/FrameworkRewritesBuilder.java
@@ -63,7 +63,7 @@ public class FrameworkRewritesBuilder implements HandlerBuilder {
 			@Override
 			public HttpHandler wrap( HttpHandler toWrap ) {
 				List<PredicatedHandler> ph = PredicatedHandlersParser.parse(
-				    "not regex('^/(ws|\\.well-known)/.*')"
+				    "not regex('^/(ws(?:/.*)?|\\.well-known/.*)')"
 				        + "and not path(/favicon.ico)"
 				        + " and not path-suffix-nocase( '.cfm' )"
 				        + " and not path-suffix-nocase( '.cfc' )"

--- a/src/test/java/ortus/boxlang/web/config/MiniServerConfigTest.java
+++ b/src/test/java/ortus/boxlang/web/config/MiniServerConfigTest.java
@@ -119,6 +119,11 @@ public class MiniServerConfigTest {
 	}
 
 	@Test
+	void testNewInstance_useProxyHeaders_defaultsToFalse() {
+		assertThat( new MiniServerConfig().useProxyHeaders ).isFalse();
+	}
+
+	@Test
 	void testNewInstance_warmupUrls_defaultsToEmptyList() {
 		assertThat( new MiniServerConfig().warmupUrls ).isEmpty();
 	}
@@ -177,6 +182,16 @@ public class MiniServerConfigTest {
 		assertThat( config.host ).isEqualTo( "127.0.0.1" );
 		assertThat( config.debug ).isTrue();
 		assertThat( config.rewrites ).isTrue();
+	}
+
+	@Test
+	void testApplyJson_useProxyHeaders_parsed() throws IOException {
+		Path				tmp		= writeTempJson( "{ \"useProxyHeaders\": true }" );
+
+		MiniServerConfig	config	= new MiniServerConfig();
+		config.applyJson( tmp.toString() );
+
+		assertThat( config.useProxyHeaders ).isTrue();
 	}
 
 	@Test
@@ -303,6 +318,12 @@ public class MiniServerConfigTest {
 	void testFromArgs_rewrites_flag() {
 		MiniServerConfig config = MiniServerConfig.fromArgs( new String[] { "--rewrites" } );
 		assertThat( config.rewrites ).isTrue();
+	}
+
+	@Test
+	void testFromArgs_useProxyHeaders_flag() {
+		MiniServerConfig config = MiniServerConfig.fromArgs( new String[] { "--use-proxy-headers" } );
+		assertThat( config.useProxyHeaders ).isTrue();
 	}
 
 	@Test


### PR DESCRIPTION
This pull request introduces support for trusted reverse proxy headers in the BoxLang MiniServer, allowing the server to properly interpret `X-Forwarded-*` headers when deployed behind a proxy. The changes add a new configuration option `useProxyHeaders`, update documentation and help output, and ensure the option is respected across configuration sources (JSON, CLI, environment). Additionally, test coverage is added for the new feature, and UTF-8 encoding is enforced for form data parsing.

**Proxy header support:**
- Added a `useProxyHeaders` boolean option to `MiniServerConfig`, enabling Undertow's `ProxyPeerAddressHandler` when set to `true`. This allows the server to use `X-Forwarded-*` headers from trusted proxies for client address, host, port, and protocol. [[1]](diffhunk://#diff-9ccb7609b4edd92e30d0c985944a4be0eb08bd4685171debea587031961e6fe4R173-R175) [[2]](diffhunk://#diff-4f6340eb46594a1d068f410fa7b58145a685ad54afb6e803510f426b9dc55b10L549-R558)
- Updated configuration loading to support `useProxyHeaders` from JSON files, CLI arguments (`--use-proxy-headers`), and the `BOXLANG_USE_PROXY_HEADERS` environment variable. [[1]](diffhunk://#diff-9ccb7609b4edd92e30d0c985944a4be0eb08bd4685171debea587031961e6fe4R252) [[2]](diffhunk://#diff-9ccb7609b4edd92e30d0c985944a4be0eb08bd4685171debea587031961e6fe4R331-R332) [[3]](diffhunk://#diff-9ccb7609b4edd92e30d0c985944a4be0eb08bd4685171debea587031961e6fe4R423-R425)
- Extended documentation in `MINISERVER_JSON.md` and `readme.md` to describe the new option, its usage, and security considerations. [[1]](diffhunk://#diff-9ec9a15d15cd0e1c3044a9954335c86abd187f1733642a5e51609b18cb967874R47) [[2]](diffhunk://#diff-9ec9a15d15cd0e1c3044a9954335c86abd187f1733642a5e51609b18cb967874R276-R287) [[3]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R68)
- Updated help output and sample configs to include `useProxyHeaders`. [[1]](diffhunk://#diff-4f6340eb46594a1d068f410fa7b58145a685ad54afb6e803510f426b9dc55b10R273) [[2]](diffhunk://#diff-4f6340eb46594a1d068f410fa7b58145a685ad54afb6e803510f426b9dc55b10R768) [[3]](diffhunk://#diff-4f6340eb46594a1d068f410fa7b58145a685ad54afb6e803510f426b9dc55b10R787) [[4]](diffhunk://#diff-4f6340eb46594a1d068f410fa7b58145a685ad54afb6e803510f426b9dc55b10R802) [[5]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R46)

**Testing and versioning:**
- Added unit tests to verify default values, JSON parsing, and CLI flag handling for `useProxyHeaders` in `MiniServerConfigTest`. [[1]](diffhunk://#diff-d913048cf7e27a387fc1caa44d1df52e79192ef477f237b5c6bfcc04a62e981aR121-R125) [[2]](diffhunk://#diff-d913048cf7e27a387fc1caa44d1df52e79192ef477f237b5c6bfcc04a62e981aR187-R196) [[3]](diffhunk://#diff-d913048cf7e27a387fc1caa44d1df52e79192ef477f237b5c6bfcc04a62e981aR323-R328)
- Bumped version numbers to `1.16.0` in preparation for release. [[1]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L1-R4) [[2]](diffhunk://#diff-3bd14d078188074c410028847113ceae68865d0ad5b844a27183ef87fbe2fcc3R12-R13) [[3]](diffhunk://#diff-3bd14d078188074c410028847113ceae68865d0ad5b844a27183ef87fbe2fcc3L76-R79)

**Other improvements:**
- Enforced UTF-8 as the default encoding for both URL-encoded and multipart form data parsing in `BoxHTTPUndertowExchange`.
- Refined the regex in `FrameworkRewritesBuilder` to better exclude WebSocket paths from rewrites.