### PR TITLE
Add hotfix branch CI and manual snapshot-to-S3 publish workflow

### DIFF
--- a/.github/workflows/hotfix-snapshot.yml
+++ b/.github/workflows/hotfix-snapshot.yml
@@ -1,0 +1,42 @@
+name: Hotfix Snapshot
+
+# Manually-triggered build + publish-a-snapshot-to-S3-only workflow, runnable only
+# from a hotfix/* branch. Reuses the release pipeline's build + S3 upload mechanics
+# while explicitly skipping everything that implies a "real" release: no version
+# bump, no git tag, no GitHub Release, no GitHub Packages publish, no Maven Central
+# publish, no changelog commit, and no clobbering development's evergreen S3 alias.
+#
+# Tests are intentionally skipped here - the hotfix branch's push-triggered CI
+# (hotfix.yml) already validated the commit before this is run.
+on:
+  workflow_dispatch:
+
+jobs:
+  #############################################
+  # Guard: only allow this to run from a hotfix/* branch
+  #############################################
+  guard:
+    name: Ensure Hotfix Branch
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Verify branch is a hotfix branch
+        run: |
+          if [[ "${{ github.ref_name }}" != hotfix/* ]]; then
+            echo "::error::hotfix-snapshot.yml can only be run from a hotfix/* branch. Current branch: ${{ github.ref_name }}"
+            exit 1
+          fi
+
+  #############################################
+  # Build & Publish Snapshot to S3 Only
+  #############################################
+  build:
+    name: Build & Publish Snapshot to S3
+    needs: [guard]
+    uses: ./.github/workflows/release.yml
+    secrets: inherit
+    permissions:
+      contents: read
+    with:
+      snapshot: true
+      skipEvergreen: true

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -1,17 +1,16 @@
-name: Pull Requests
+name: Hotfix Branch CI
 
+# Gives hotfix/* branches the same push-triggered feedback (tests + formatting)
+# that other feature branches get via pr.yml, so a hotfix can be validated
+# before it's merged or published via hotfix-snapshot.yml.
 on:
   push:
-    branches-ignore:
-      - "main"
-      - "master"
-      - "development"
-      - "releases/v*"
-      - "hotfix/**"
-  pull_request:
     branches:
-      - "releases/v*"
-      - development
+      - "hotfix/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   tests:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ on:
         required: false
         default: false
         type: boolean
+      skipEvergreen:
+        description: "Skip the evergreen 'latest snapshot' S3 upload (used for ad-hoc snapshot builds, e.g. from a hotfix branch, that must not clobber development's evergreen alias)"
+        required: false
+        default: false
+        type: boolean
 
   # Manual Trigger for LTS Releases
   workflow_dispatch:
@@ -30,6 +35,7 @@ on:
 env:
   MODULE_ID: ${{ github.event.repository.name }}
   SNAPSHOT: ${{ inputs.snapshot || false }}
+  SKIP_EVERGREEN: ${{ inputs.skipEvergreen || false }}
   JDK: 21
   BUILD_ID: ${{ github.run_number }}
   LTS: ${{ inputs.lts || false }}
@@ -64,20 +70,34 @@ jobs:
         id: current_version
         run: |
           TMPVERSION=$(grep '^version=' gradle.properties | cut -d'=' -f2)
-          if [[ "${{ github.ref }}" == "refs/heads/development" ]]; then
-            # Replace existing prerelease identifier with -snapshot or append -snapshot if none exists
-            TMPVERSION=$(echo $TMPVERSION | sed 's/-.*$//')-snapshot
+          # Strip any existing prerelease identifier to get the base version
+          BASEVERSION=$(echo $TMPVERSION | sed 's/-.*$//')
+
+          # Whether this is a snapshot build is decided by the `snapshot` input (via $SNAPSHOT),
+          # not by which branch we happen to be on - that let a hotfix/* snapshot silently build
+          # unversioned, since it isn't the `development` branch.
+          if [ "$SNAPSHOT" == "true" ]; then
+            if [ "$GITHUB_REF" == "refs/heads/development" ]; then
+              TMPVERSION="${BASEVERSION}-snapshot"
+            else
+              # Branch-scope the suffix so a non-development snapshot (e.g. a hotfix branch)
+              # can never collide with development's snapshot version/S3 path
+              SAFE_BRANCH=$(echo "${GITHUB_REF#refs/heads/}" | tr -c 'a-zA-Z0-9' '-')
+              TMPVERSION="${BASEVERSION}-${SAFE_BRANCH}-snapshot"
+            fi
           fi
           echo "VERSION=$TMPVERSION" >> $GITHUB_ENV
 
-          # Branche
+          # Branch
           echo "Github Ref is $GITHUB_REF"
-          echo "BRANCH=main" >> $GITHUB_ENV
-
-          # Snapshot
-          if [ $GITHUB_REF == 'refs/heads/development' ]
-          then
+          # build.gradle's `branch == 'development'` check drives its own -snapshot suffix on
+          # build artifact filenames and its evergreen alias naming, so keep BRANCH=development
+          # for ANY snapshot build (not just literal development) to keep gradle-level and
+          # workflow-level version logic in sync.
+          if [ "$SNAPSHOT" == "true" ]; then
             echo "BRANCH=development" >> $GITHUB_ENV
+          else
+            echo "BRANCH=main" >> $GITHUB_ENV
           fi
 
       - name: Update changelog [unreleased] with latest version
@@ -132,6 +152,7 @@ jobs:
           DEST_DIR: "ortussolutions/boxlang-runtimes/${{ env.MODULE_ID }}/${{ env.VERSION }}"
 
       - name: Upload Evergreen Distributions to S3
+        if: env.SKIP_EVERGREEN == 'false'
         uses: jakejarvis/s3-sync-action@master
         with:
           args: --acl public-read
@@ -202,7 +223,7 @@ jobs:
   ##########################################################################################
   prep_next_release:
     name: Prep Next Release
-    if: github.ref != 'refs/heads/development'
+    if: ${{ inputs.snapshot != true }}
     runs-on: ubuntu-latest
     needs: [build]
     permissions:


### PR DESCRIPTION
## Description

Adds a `hotfix/*` branch workflow (same pattern as [ortus-boxlang/bx-web-support#40](https://github.com/ortus-boxlang/bx-web-support/pull/40), adapted to this repo's release pipeline):

1. **Push CI for `hotfix/*` branches** (`hotfix.yml`) — mirrors `pr.yml`'s `tests` + `format_check` jobs so a hotfix branch gets the same CI feedback as any other feature branch, before it's merged or published.
2. **Manual snapshot-to-S3 publish** (`hotfix-snapshot.yml`) — `workflow_dispatch`-only, guarded to only run from a `hotfix/*` branch. Builds and publishes a snapshot to S3 by reusing `release.yml` with `snapshot: true`, skipping tests (the branch's push CI already validated the commit) and skipping everything that implies a "real" release: no version bump, no git tag, no GitHub Release, no GitHub Packages publish, no Maven Central publish, no changelog commit, and no evergreen S3 alias upload.
3. **Root-cause fix in `release.yml`** — snapshot detection (both the build's `VERSION` string and the `BRANCH` env var consumed by `build.gradle`) was hardcoded to `github.ref == 'refs/heads/development'` instead of reading the `snapshot` input. This was silently correct only because `snapshot.yml` (the one existing caller) always runs on `development`; calling the pipeline from a `hotfix/*` branch would hit this directly — the build would not be versioned/uploaded as a snapshot. Now:
   - Version/branch decisions key off the `snapshot` input (`$SNAPSHOT`) instead of a literal branch check.
   - A non-`development` snapshot gets a branch-scoped version suffix (e.g. `<base>-hotfix-foo-snapshot`) so it can never collide with `development`'s snapshot S3 path.
   - `prep_next_release`'s job-level `if:` (which read `github.ref != 'refs/heads/development'`, and would have incorrectly run — checking out and version-bumping `development` — for a hotfix `workflow_call`) now reads `inputs.snapshot != true` instead (job-level `if:` can't read `env`).
   - New `skipEvergreen` input on `release.yml` (default `false`, additive/backward-compatible) gates the "Upload Evergreen Distributions to S3" step, which uploads to the non-version-keyed `ortussolutions/boxlang-runtimes/<module>/` path that `development`'s shared `boxlang-miniserver-snapshot.zip`/`.jar` alias files live in. This protects that shared path from a hotfix run, without touching the existing `snapshot.yml`/`development` behavior.
4. **`pr.yml`** — added `hotfix/**` to `push.branches-ignore` so a hotfix push isn't double-CI'd by both `pr.yml` and the new `hotfix.yml`. The existing `pull_request` trigger is unchanged, so a hotfix branch later PR'd into `development` still gets CI via that path.

No new GitHub secrets are required — `hotfix-snapshot.yml` reuses the existing AWS credentials via `secrets: inherit`. The `prep_next_release` job's existing LTS handling (`inputs.lts`) is untouched — it's only reachable via a non-snapshot `workflow_dispatch`, which the new flow doesn't use.

## Jira/Github Issues

No accompanying Jira/issue was provided for this change; please link one if required before merge.

## Type of change

- [x] Improvement
- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

These changes are GitHub Actions workflow config only; verification is via live Actions runs (see below) rather than unit tests.

## Verification plan

- Push to a `hotfix/*` branch and confirm `hotfix.yml` fires (tests + format_check) and `pr.yml` does not also fire on the same push.
- Manually run `hotfix-snapshot.yml` from a `hotfix/*` branch via the Actions UI — confirm the guard job passes, tests are skipped, the build runs, `VERSION` resolves to `<base>-<branch>-snapshot`, S3 uploads target that version path, and "Upload Evergreen Distributions to S3" is skipped.
- Manually dispatch `hotfix-snapshot.yml` from a non-`hotfix/*` branch and confirm the guard job fails fast.
- Confirm `snapshot.yml` on `development` still resolves `VERSION` to the plain `<base>-snapshot` form and still runs the evergreen S3 upload (no regression).
- Confirm a push to `main`/`master` still runs `release.yml`'s full stable path unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_014TtrVCPw52WPrVwMJo8rxL)_